### PR TITLE
The "beacon" echo supports both UTF-8 and GBK.

### DIFF
--- a/Extenders/agent_beacon/pl_utils.go
+++ b/Extenders/agent_beacon/pl_utils.go
@@ -4,7 +4,9 @@ import (
 	"crypto/rc4"
 	"errors"
 	"fmt"
+	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/simplifiedchinese"
 	"golang.org/x/text/transform"
 	"io"
 	"net"
@@ -78,41 +80,43 @@ const (
 	BOF_ERROR_ALLOC     = 0x105
 )
 
-var codePageMapping = map[int]*charmap.Charmap{
-	037:   charmap.CodePage037,  // IBM EBCDIC US-Canada
-	437:   charmap.CodePage437,  // OEM United States
-	850:   charmap.CodePage850,  // Western European (DOS)
-	852:   charmap.CodePage852,  // Central European (DOS)
-	855:   charmap.CodePage855,  // OEM Cyrillic (primarily Russian)
-	858:   charmap.CodePage858,  // OEM Multilingual Latin 1 + Euro
-	860:   charmap.CodePage860,  // Portuguese (DOS)
-	862:   charmap.CodePage862,  // Hebrew (DOS)
-	863:   charmap.CodePage863,  // French Canadian (DOS)
-	865:   charmap.CodePage865,  // Nordic (DOS)
-	866:   charmap.CodePage866,  // Russian (DOS)
-	1047:  charmap.CodePage1047, // IBM EBCDIC Latin 1/Open System
-	1140:  charmap.CodePage1140, // IBM EBCDIC US-Canada with Euro
-	1250:  charmap.Windows1250,  // Central European (Windows)
-	1251:  charmap.Windows1251,  // Cyrillic (Windows)
-	1252:  charmap.Windows1252,  // Western European (Windows)
-	1253:  charmap.Windows1253,  // Greek (Windows)
-	1254:  charmap.Windows1254,  // Turkish (Windows)
-	1255:  charmap.Windows1255,  // Hebrew (Windows)
-	1256:  charmap.Windows1256,  // Arabic (Windows)
-	1257:  charmap.Windows1257,  // Baltic (Windows)
-	1258:  charmap.Windows1258,  // Vietnamese (Windows)
-	20866: charmap.KOI8R,        // Russian (KOI8-R)
-	21866: charmap.KOI8U,        // Ukrainian (KOI8-U)
-	28591: charmap.ISO8859_1,    // Western European (ISO 8859-1)
-	28592: charmap.ISO8859_2,    // Central European (ISO 8859-2)
-	28593: charmap.ISO8859_3,    // Latin 3 (ISO 8859-3)
-	28594: charmap.ISO8859_4,    // Baltic (ISO 8859-4)
-	28595: charmap.ISO8859_5,    // Cyrillic (ISO 8859-5)
-	28596: charmap.ISO8859_6,    // Arabic (ISO 8859-6)
-	28597: charmap.ISO8859_7,    // Greek (ISO 8859-7)
-	28598: charmap.ISO8859_8,    // Hebrew (ISO 8859-8)
-	28599: charmap.ISO8859_9,    // Turkish (ISO 8859-9)
-	28605: charmap.ISO8859_15,   // Latin 9 (ISO 8859-15)
+var codePageMapping = map[int]encoding.Encoding{
+	037:   charmap.CodePage037,   // IBM EBCDIC US-Canada
+	437:   charmap.CodePage437,   // OEM United States
+	850:   charmap.CodePage850,   // Western European (DOS)
+	852:   charmap.CodePage852,   // Central European (DOS)
+	855:   charmap.CodePage855,   // OEM Cyrillic (primarily Russian)
+	858:   charmap.CodePage858,   // OEM Multilingual Latin 1 + Euro
+	860:   charmap.CodePage860,   // Portuguese (DOS)
+	862:   charmap.CodePage862,   // Hebrew (DOS)
+	863:   charmap.CodePage863,   // French Canadian (DOS)
+	865:   charmap.CodePage865,   // Nordic (DOS)
+	866:   charmap.CodePage866,   // Russian (DOS)
+	936:   simplifiedchinese.GBK, // Chinese (GBK)
+	1047:  charmap.CodePage1047,  // IBM EBCDIC Latin 1/Open System
+	1140:  charmap.CodePage1140,  // IBM EBCDIC US-Canada with Euro
+	1250:  charmap.Windows1250,   // Central European (Windows)
+	1251:  charmap.Windows1251,   // Cyrillic (Windows)
+	1252:  charmap.Windows1252,   // Western European (Windows)
+	1253:  charmap.Windows1253,   // Greek (Windows)
+	1254:  charmap.Windows1254,   // Turkish (Windows)
+	1255:  charmap.Windows1255,   // Hebrew (Windows)
+	1256:  charmap.Windows1256,   // Arabic (Windows)
+	1257:  charmap.Windows1257,   // Baltic (Windows)
+	1258:  charmap.Windows1258,   // Vietnamese (Windows)
+	20866: charmap.KOI8R,         // Russian (KOI8-R)
+	21866: charmap.KOI8U,         // Ukrainian (KOI8-U)
+	28591: charmap.ISO8859_1,     // Western European (ISO 8859-1)
+	28592: charmap.ISO8859_2,     // Central European (ISO 8859-2)
+	28593: charmap.ISO8859_3,     // Latin 3 (ISO 8859-3)
+	28594: charmap.ISO8859_4,     // Baltic (ISO 8859-4)
+	28595: charmap.ISO8859_5,     // Cyrillic (ISO 8859-5)
+	28596: charmap.ISO8859_6,     // Arabic (ISO 8859-6)
+	28597: charmap.ISO8859_7,     // Greek (ISO 8859-7)
+	28598: charmap.ISO8859_8,     // Hebrew (ISO 8859-8)
+	28599: charmap.ISO8859_9,     // Turkish (ISO 8859-9)
+	28605: charmap.ISO8859_15,    // Latin 9 (ISO 8859-15)
+	65001: encoding.Nop,          // Unicode (UTF-8)
 }
 
 var win32ErrorCodes = map[uint]string{


### PR DESCRIPTION
Fix https://github.com/Adaptix-Framework/AdaptixC2/issues/13

Now, Chinese characters and other symbols can be correctly displayed in the console without any garbled text.
<img width="1178" alt="iShot_2025-03-18_12 49 23" src="https://github.com/user-attachments/assets/138159ff-5ab1-4418-a49a-2cf07497e45b" />
