### PR TITLE
[Fix] Memory Leak in ProcessDownloadTasks

### DIFF
--- a/Extenders/agent_beacon/src_beacon/beacon/Downloader.cpp
+++ b/Extenders/agent_beacon/src_beacon/beacon/Downloader.cpp
@@ -85,4 +85,8 @@ void Downloader::ProcessDownloadTasks(Packer* packer)
 			--i;
 		}
 	}
+	// Free Allocated Buffer
+	if (buffer) {
+		ApiWin->LocalFree(buffer);
+	}
 }


### PR DESCRIPTION
The `ProcessDownloadTasks` function doesn't properly free the allocated buffer resulting into a memory leak and high memory usage. 
 
![HeavyMemoryUsage](https://github.com/user-attachments/assets/d5794050-8328-458f-9660-6a11e326cee1)

![DownloadNotReleasingMemory](https://github.com/user-attachments/assets/3f6ff355-bb5c-4243-86f7-e2f690df9f55)

- Ensure the buffer is free after processing downloads
![FixedMemoryLeak](https://github.com/user-attachments/assets/91f11c1a-545a-42a0-835e-880cd2801e16)
