### PR TITLE
bug fix in Extenders/listener_beacon_http/pl_http.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Extenders/listener_beacon_http/pl_http.go
+++ b/Extenders/listener_beacon_http/pl_http.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"io"
 	"math/big"
 	"net/http"
@@ -20,6 +19,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
 type HTTPConfig struct {
@@ -256,9 +257,9 @@ func (handler *HTTP) parseBeatAndData(ctx *gin.Context) (string, string, []byte,
 		err            error
 	)
 
-	params := ctx.Request.Header[handler.Config.ParameterName]
+	params := ctx.Request.Header.Get(handler.Config.ParameterName)
 	if len(params) > 0 {
-		beat = params[0]
+		beat = params
 	} else {
 		return "", "", nil, nil, errors.New("missing beat from Headers")
 	}


### PR DESCRIPTION
When setting custom headers AdaptixC2/Extenders/listener_beacon_http/config.json, line 259 in AdaptixC2/Extenders/listener_beacon_http/pl_http.go would not parse the json correctly.  The bug was caused by how the code attempted to retrieve the custom heartbeat header from incoming HTTP requests. Basically, case sensitivity was affecting the parsing. 

Changed to ctx.Request.Header.Get(handler.Config.ParameterName) to ensure the header is found regardless of case, and works with any custom header name specified in the config.json.