### PR TITLE
update Makefile compatible with macos

### DIFF
--- a/Extenders/agent_beacon/src_beacon/Makefile
+++ b/Extenders/agent_beacon/src_beacon/Makefile
@@ -35,7 +35,7 @@ COMMON_FLAGS := -I $(BEACON_DIR) \
 
 .PHONY: all clean pre x64 x86
 
-NPROC := $(shell nproc)
+NPROC := $(shell if command -v nproc > /dev/null; then nproc; else sysctl -n hw.logicalcpu; fi)
 ifeq ($(MAKELEVEL), 0)
     MAKEFLAGS += -j$(NPROC) --no-print-directory
 endif

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ clean:
 server: prepare
 	@ echo "[*] Building adaptixserver..."
 	@ cd AdaptixServer && go build -ldflags="-s -w" -o adaptixserver > /dev/null 2>build_error.log || { echo "[ERROR] Failed to build AdaptixServer:"; cat build_error.log >&2; exit 1; }     # for static build use CGO_ENABLED=0
-	@ sudo setcap 'cap_net_bind_service=+ep' AdaptixServer/adaptixserver
+	@ if [ "$$(uname)" != "Darwin" ]; then \
+		sudo setcap 'cap_net_bind_service=+ep' AdaptixServer/adaptixserver; \
+	fi
 	@ mv AdaptixServer/adaptixserver ./$(DIST_DIR)/
 	@ cp AdaptixServer/ssl_gen.sh AdaptixServer/profile.json AdaptixServer/404page.html ./$(DIST_DIR)/
 	@ echo "[+] done"


### PR DESCRIPTION
macOS does not support the setcap and nproc commands. Update the compatibility method to suppress makefile error messages.

```
[*] Building adaptixserver...
Password:
sudo: setcap: command not found
make: *** [server] Error 1
.....
.....
make[2]: nproc: Command not found
```