### PR TITLE
Use X-Forwarded-For only if enabled and present

### DIFF
--- a/Extenders/listener_beacon_http/pl_http.go
+++ b/Extenders/listener_beacon_http/pl_http.go
@@ -205,9 +205,10 @@ func (handler *HTTP) processRequest(ctx *gin.Context) {
 		return
 	}
 
-	ExternalIP = strings.Split(ctx.Request.RemoteAddr, ":")[0]
-	if handler.Config.TrustXForwardedFor {
+	if handler.Config.TrustXForwardedFor && ctx.Request.Header.Get("X-Forwarded-For") != "" {
 		ExternalIP = ctx.Request.Header.Get("X-Forwarded-For")
+	} else {
+		ExternalIP = strings.Split(ctx.Request.RemoteAddr, ":")[0]
 	}
 
 	agentType, agentId, beat, bodyData, err = handler.parseBeatAndData(ctx)


### PR DESCRIPTION
Use the X-Forwarded-For header only when TrustXForwardedFor is enabled and the header is present. Falls back to RemoteAddr otherwise.