### PR TITLE
Add validation for packer size in ProcessCommandTasks

### DIFF
--- a/Extenders/agent_beacon/src_beacon/beacon/Commander.cpp
+++ b/Extenders/agent_beacon/src_beacon/beacon/Commander.cpp
@@ -15,6 +15,14 @@ void Commander::ProcessCommandTasks(BYTE* recv, ULONG recvSize, Packer* outPacke
 	*inPacker = Packer( recv, recvSize );
 
 	ULONG packerSize = inPacker->Unpack32();
+
+	// Check if the packer size is valid
+	if (packerSize > recvSize - 4)
+	{
+		MemFreeLocal((LPVOID*)&inPacker, sizeof(Packer));
+ 		return;
+	}
+
 	while ( packerSize + 4 > inPacker->datasize())
 	{	
 		ULONG CommandId = inPacker->Unpack32();


### PR DESCRIPTION
Sanity check in `Commander::ProcessCommandTasks` to validate the packer size before processing commands