### PR TITLE
fix(agent_gopher): resolve macOS agent generation issue

### DIFF
--- a/Extenders/agent_gopher/pl_agent.go
+++ b/Extenders/agent_gopher/pl_agent.go
@@ -165,7 +165,7 @@ func AgentGenerateBuild(agentConfig string, agentProfile []byte, listenerMap map
 	if generateConfig.Os == "linux" {
 		Filename = "agent.bin"
 		GoOs = "linux"
-	} else if generateConfig.Os == "mac" {
+	} else if generateConfig.Os == "mac" || generateConfig.Os == "macos" {
 		Filename = "agent.bin"
 		GoOs = "darwin"
 	} else if generateConfig.Os == "windows" {


### PR DESCRIPTION
The UI uses "macos" identifier but the code only checked for "mac", causing "operating system not supported" error:

<img width="1508" height="1504" alt="image" src="https://github.com/user-attachments/assets/4c616e02-d0f1-4494-b228-3f4825f9c664" />


 This fix adds support for both identifiers to ensure proper macOS agent generation.