### PR TITLE
fix(jobTerminal): add process.Wait() after wg.Wait() to avoid defunct

### DIFF
--- a/Extenders/agent_gopher/src_gopher/tasks.go
+++ b/Extenders/agent_gopher/src_gopher/tasks.go
@@ -1159,6 +1159,7 @@ func jobTerminal(paramsData []byte) {
 		}()
 
 		wg.Wait()
+		_ = process.Wait()
 
 		cancel()
 	}()


### PR DESCRIPTION
Fix jobTerminal zombie (<defunct>) processes by adding process.Wait() after wg.Wait().
