### PR TITLE
Fix/getuid 131

### DIFF
--- a/AdaptixClient/Headers/Client/AxScript/AxCommandWrappers.h
+++ b/AdaptixClient/Headers/Client/AxScript/AxCommandWrappers.h
@@ -17,18 +17,13 @@ public:
 
     Q_INVOKABLE void addSubCommands(const QJSValue& array);
 
-    Q_INVOKABLE void addArgBool(const QString &flag, const QString &description = "");
-    Q_INVOKABLE void addArgBool(const QString &flag, const QString &description, const QJSValue &value);
+    Q_INVOKABLE void addArgBool(const QString &flag, const QJSValue &arg2 = QJSValue(), const QJSValue &arg3 = QJSValue());
 
-    Q_INVOKABLE void addArgInt(const QString &name, bool required = false, const QString &description = "");
-    Q_INVOKABLE void addArgInt(const QString &name, const QString &description, const QJSValue &value);
-    Q_INVOKABLE void addArgFlagInt(const QString &flag, const QString &name, bool required = false, const QString &description = "");
-    Q_INVOKABLE void addArgFlagInt(const QString &flag, const QString &name, const QString &description, const QJSValue &value);
+    Q_INVOKABLE void addArgInt(const QString &name, const QJSValue &arg2 = QJSValue(), const QJSValue &arg3 = QJSValue());
+    Q_INVOKABLE void addArgFlagInt(const QString &flag, const QString &name, const QJSValue &arg3 = QJSValue(), const QJSValue &arg4 = QJSValue());
 
-    Q_INVOKABLE void addArgString(const QString &name, bool required = false, const QString &description = "");
-    Q_INVOKABLE void addArgString(const QString &name, const QString &description, const QJSValue &value);
-    Q_INVOKABLE void addArgFlagString(const QString &flag, const QString &name, bool required = false, const QString &description = "");
-    Q_INVOKABLE void addArgFlagString(const QString &flag, const QString &name, const QString &description, const QJSValue &value);
+    Q_INVOKABLE void addArgString(const QString &name, const QJSValue &arg2 = QJSValue(), const QJSValue &arg3 = QJSValue());
+    Q_INVOKABLE void addArgFlagString(const QString &flag, const QString &name, const QJSValue &arg3 = QJSValue(), const QJSValue &arg4 = QJSValue());
 
     Q_INVOKABLE void addArgFile(const QString &name, bool required = false, const QString &description = "");
     Q_INVOKABLE void addArgFlagFile(const QString &flag, const QString &name, bool required = false, const QString &description = "");

--- a/AdaptixClient/Source/Client/AxScript/AxCommandWrappers.cpp
+++ b/AdaptixClient/Source/Client/AxScript/AxCommandWrappers.cpp
@@ -42,91 +42,97 @@ void AxCommandWrappers::addSubCommands(const QJSValue& value)
 
 }
 
-void AxCommandWrappers::addArgBool(const QString &flag, const QString &description)
+void AxCommandWrappers::addArgBool(const QString &flag, const QJSValue &arg2, const QJSValue &arg3)
 {
-    Argument arg = { "BOOL", "", false, true, flag, description, false, QVariant() };
-    command.args.append(arg);
-}
+    Argument arg = { "BOOL", "", false, true, flag, "", false, QVariant() };
 
-void AxCommandWrappers::addArgBool(const QString &flag, const QString &description, const QJSValue &value)
-{
-    Argument arg = { "BOOL", "", true, true, flag, description, false, QVariant() };
+    if (arg2.isString()) {
+        arg.description = arg2.toString();
 
-    if ( !value.isUndefined() && !value.isNull() ) {
-        arg.defaultUsed = true;
-        arg.defaultValue = value.toVariant();
+        if (!arg3.isUndefined() && !arg3.isNull()) {
+            arg.defaultUsed = true;
+            arg.defaultValue = arg3.toVariant();
+        }
     }
 
     command.args.append(arg);
 }
 
-void AxCommandWrappers::addArgInt(const QString &name, const bool required, const QString &description)
+void AxCommandWrappers::addArgInt(const QString &name, const QJSValue &arg2, const QJSValue &arg3)
 {
-    Argument arg = { "INT", name, required, false, "", description, false, QVariant() };
-    command.args.append(arg);
-}
+    Argument arg = { "INT", name, false, false, "", "", false, QVariant() };
 
-void AxCommandWrappers::addArgInt(const QString &name, const QString &description, const QJSValue &value)
-{
-    Argument arg = { "INT", name, true, false, "", description, false, QVariant() };
+    if (arg2.isBool()) {
+        arg.required = arg2.toBool();
+        arg.description = arg3.isString() ? arg3.toString() : "";
+    } else if (arg2.isString()) {
+        arg.required = true;
+        arg.description = arg2.toString();
 
-    if ( !value.isUndefined() && !value.isNull() ) {
-        arg.defaultUsed = true;
-        arg.defaultValue = value.toVariant();
+        if (!arg3.isUndefined() && !arg3.isNull()) {
+            arg.defaultUsed = true;
+            arg.defaultValue = arg3.toVariant();
+        }
     }
 
     command.args.append(arg);
 }
 
-void AxCommandWrappers::addArgFlagInt(const QString &flag, const QString &name, const bool required, const QString &description)
+void AxCommandWrappers::addArgFlagInt(const QString &flag, const QString &name, const QJSValue &arg3, const QJSValue &arg4)
 {
-    Argument arg = { "INT", name, required, true, flag, description, false, QVariant() };
-    command.args.append(arg);
-}
+    Argument arg = { "INT", name, false, true, flag, "", false, QVariant() };
 
-void AxCommandWrappers::addArgFlagInt(const QString &flag, const QString &name, const QString &description, const QJSValue &value)
-{
-    Argument arg = { "INT", name, true, true, flag, description, false, QVariant() };
+    if (arg3.isBool()) {
+        arg.required = arg3.toBool();
+        arg.description = arg4.isString() ? arg4.toString() : "";
+    } else if (arg3.isString()) {
+        arg.required = true;
+        arg.description = arg3.toString();
 
-    if ( !value.isUndefined() && !value.isNull() ) {
-        arg.defaultUsed = true;
-        arg.defaultValue = value.toVariant();
+        if (!arg4.isUndefined() && !arg4.isNull()) {
+            arg.defaultUsed = true;
+            arg.defaultValue = arg4.toVariant();
+        }
     }
 
     command.args.append(arg);
 }
 
-void AxCommandWrappers::addArgString(const QString &name, const bool required, const QString &description)
+void AxCommandWrappers::addArgString(const QString &name, const QJSValue &arg2, const QJSValue &arg3)
 {
-    Argument arg = { "STRING", name, required, false, "", description, false, QVariant() };
-    command.args.append(arg);
-}
+    Argument arg = { "STRING", name, true, false, "", "", false, QVariant() };
 
-void AxCommandWrappers::addArgString(const QString &name, const QString &description, const QJSValue &value)
-{
-    Argument arg = { "STRING", name, true, false, "", description, false, QVariant() };
+    if (arg2.isBool()) {
+        arg.required = arg2.toBool();
+        arg.description = arg3.isString() ? arg3.toString() : "";
+    }
+    else if (arg2.isString()) {
+        arg.description = arg2.toString();
 
-    if ( !value.isUndefined() && !value.isNull() ) {
-        arg.defaultUsed = true;
-        arg.defaultValue = value.toVariant();
+        if (!arg3.isUndefined() && !arg3.isNull()) {
+            arg.defaultUsed = true;
+            arg.defaultValue = arg3.toVariant();
+        }
     }
 
     command.args.append(arg);
 }
 
-void AxCommandWrappers::addArgFlagString(const QString &flag, const QString &name, const bool required, const QString &description)
+void AxCommandWrappers::addArgFlagString(const QString &flag, const QString &name, const QJSValue &arg3, const QJSValue &arg4)
 {
-    Argument arg = { "STRING", name, required, true, flag, description, false, QVariant() };
-    command.args.append(arg);
-}
+    Argument arg = { "STRING", name, false, true, flag, "", false, QVariant() };
 
-void AxCommandWrappers::addArgFlagString(const QString &flag, const QString &name, const QString &description, const QJSValue &value)
-{
-    Argument arg = { "STRING", name, true, true, flag, description, false, QVariant() };
+    if (arg3.isBool()) {
+        arg.required = arg3.toBool();
+        arg.description = arg4.isString() ? arg4.toString() : "";
+    } else if (arg3.isString()) {
+        arg.required = true;
+        arg.description = arg3.toString();
 
-    if ( !value.isUndefined() && !value.isNull() ) {
-        arg.defaultUsed = true;
-        arg.defaultValue = value.toVariant();
+        if (!arg4.isUndefined() && !arg4.isNull()) {
+            arg.defaultUsed = true;
+            arg.defaultValue = arg4.toVariant();
+        }
     }
 
     command.args.append(arg);
@@ -154,7 +160,6 @@ void AxCommandWrappers::setPreHook(const QJSValue &handler)
     command.is_pre_hook = true;
     command.pre_hook = handler;
 }
-
 
 AxCommandGroupWrapper::AxCommandGroupWrapper(QJSEngine* engine, QObject* parent) : QObject(parent), parent(parent), engine(engine) {}
 
@@ -186,7 +191,8 @@ QList<Command> AxCommandGroupWrapper::getCommands() const { return commands; }
 
 QJSEngine* AxCommandGroupWrapper::getEngine() const { return this->engine; }
 
-void AxCommandGroupWrapper::add(const QJSValue &value) {
+void AxCommandGroupWrapper::add(const QJSValue &value)
+{
     if (value.isUndefined() || value.isNull())
         return;
 

--- a/Extenders/agent_beacon/src_beacon/beacon/Commander.cpp
+++ b/Extenders/agent_beacon/src_beacon/beacon/Commander.cpp
@@ -350,7 +350,6 @@ void Commander::CmdGetUid(ULONG commandId, Packer* inPacker, Packer* outPacker)
 		result = TokenToUser(TokenHandle, username, &usernameSize, domain, &domainSize, &elevated);
 
 	if (result) {
-		outPacker->Pack8(FALSE);
 		outPacker->Pack8(elevated);
 		outPacker->PackStringA(domain);
 		outPacker->PackStringA(username);
@@ -998,7 +997,6 @@ void Commander::AlertImpersonated(Packer* outPacker)
 
 			outPacker->Pack32(COMMAND_GETUID);
 
-			outPacker->Pack8(TRUE);
 			outPacker->Pack8(elevated);
 			outPacker->PackStringA(domain);
 			outPacker->PackStringA(username);

--- a/Extenders/agent_gopher/ax_config.axs
+++ b/Extenders/agent_gopher/ax_config.axs
@@ -253,6 +253,7 @@ function GenerateUI(listenerType)
     container.put("format", comboFormat)
     container.put("reconn_timeout", textReconnTimeout)
     container.put("reconn_count", spinReconnCount)
+    container.put("win7_support", checkWin7)
 
     let panel = form.create_panel()
     panel.setLayout(layout)


### PR DESCRIPTION
# Fix: Remove unused GUI flag from getuid protocol

The getuid command was failing due to a protocol mismatch introduced during impersonation system refactoring. The C++ beacon was sending an unused GUI flag that the Go server wasn't expecting. Removed this redundant flag to align both sides of the protocol.

fix:#131
