### PR TITLE
Feat: Webhook support

### DIFF
--- a/AdaptixServer/core/profile/utils.go
+++ b/AdaptixServer/core/profile/utils.go
@@ -30,7 +30,20 @@ type TsCallback struct {
 		Token   string   `json:"token"`
 		ChatsId []string `json:"chats_id"`
 	} `json:"Telegram"`
-	NewAgentMessage    string `json:"new_agent_message"`
-	NewCredMessage     string `json:"new_cred_message"`
-	NewDownloadMessage string `json:"new_download_message"`
+	Webhooks           []WebhookConfig `json:"webhooks"`
+	NewAgentMessage    string          `json:"new_agent_message"`
+	NewCredMessage     string          `json:"new_cred_message"`
+	NewDownloadMessage string          `json:"new_download_message"`
+}
+
+type WebhookConfig struct {
+	URL       string            `json:"url"`
+	Method    string            `json:"method"`
+	Headers   map[string]string `json:"headers"`
+	BasicAuth *BasicAuth        `json:"basic_auth,omitempty"`
+}
+
+type BasicAuth struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
 }

--- a/AdaptixServer/profile.json
+++ b/AdaptixServer/profile.json
@@ -17,7 +17,6 @@
     "access_token_live_hours": 12,
     "refresh_token_live_hours": 168
   },
-
   "ServerResponse": {
     "status": 404,
     "headers": {
@@ -27,14 +26,23 @@
     },
     "page": "404page.html"
   },
-
   "EventCallback": {
     "Telegram": {
       "token": "",
       "chats_id": []
     },
+    "webhooks": [
+      {
+        "url": "https://ntfy.sh/your-topic",
+        "method": "POST",
+        "headers": {
+          "Content-Type": "text/plain",
+          "Authorization": "Bearer <token>"
+        }
+      }
+    ],
     "new_agent_message": "New agent: %type% (%id%)\n\n%user% @ %computer% (%internalip%)\nelevated: %elevated%\nfrom: %externalip%\ndomain: %domain%",
     "new_cred_message": "New secret [%type%]:\n\n%username% : %password% (%domain%)\n\nStorage: %storage%\nHost: %host%",
-    "new_download_message":"File saved: %path% [%size%] from %computer% (%user%)"
+    "new_download_message": "File saved: %path% [%size%] from %computer% (%user%)"
   }
 }


### PR DESCRIPTION
Basic feature that implements webhooks in tandem with Telegram. The goal of this is to allow for webhook notifications through ntfy.sh, slack, or teams for beacon call backs. Example screenshot of a call back through ntfy.sh:

<img width="1246" height="295" alt="image" src="https://github.com/user-attachments/assets/eacc767a-f7d2-4ea0-bad4-bbdf9b9ef099" />
