### PR TITLE
Fix duplicate remote shell writes in teamserver

### DIFF
--- a/AdaptixServer/core/server/ts_terminal.go
+++ b/AdaptixServer/core/server/ts_terminal.go
@@ -266,7 +266,6 @@ func relayWebsocketToTerminal(ts *Teamserver, agent *Agent, terminal *Terminal, 
 					n, err := terminal.prSrv.Read(buf)
 					if n > 0 {
 						taskData := terminal.Callbacks.Write(terminal.TerminalId, terminal.CodePage, buf[:n])
-						tunnelManageTask(agent, taskData)
 						relayPipeToTaskData(agent, terminal.TerminalId, taskData)
 					}
 					if err != nil {


### PR DESCRIPTION
Remove the extra enqueue of shell write tasks in the terminal relay so each user command is sent only once to the beacon, preventing duplicate execution.