### PR TITLE
fix gopher beacon

### DIFF
--- a/AdaptixServer/extenders/gopher_agent/pl_main.go
+++ b/AdaptixServer/extenders/gopher_agent/pl_main.go
@@ -404,9 +404,9 @@ func (p *PluginAgent) BuildPayload(profile adaptix.BuildProfile, agentProfiles [
 
 	_ = Ts.TsAgentBuildLog(profile.BuilderId, adaptix.BUILD_LOG_INFO, fmt.Sprintf("Target: %s/%s, Output: %s", GoOs, GoArch, Filename))
 
-	config := "package main\n\nvar encProfiles = [][]byte{"
+	config := "package main\n\nvar encProfiles = [][]byte{\n"
 	for _, profile := range agentProfiles {
-		config += fmt.Sprintf("    []byte(\"%s\")\n", profile)
+		config += fmt.Sprintf("    []byte(\"%s\"),\n", profile)
 	}
 	config += "}\n"
 


### PR DESCRIPTION
Fixes gopher beacon generate error. 

```python
  Started TCP listener 'gopher': 127.0.0.1:80
\x6f\x9c\x57\x1d\x62......\x39\x96
[-] Agent build channel error: exit status 1: # gopher
./config.go:3: syntax error: unexpected newline in composite literal; possibly missing comma or }
 [26/01 01:49:01]
 ```
 