### PR TITLE
Fix gopher socks

### DIFF
--- a/AdaptixServer/extenders/gopher_agent/pl_main.go
+++ b/AdaptixServer/extenders/gopher_agent/pl_main.go
@@ -139,7 +139,25 @@ func (ext *ExtenderAgent) TunnelCallbacks() adaptix.TunnelCallbacks {
 		WriteUDP:   TunnelMessageWriteUDP,
 		Close:      TunnelMessageClose,
 		Reverse:    TunnelMessageReverse,
+		Pause:      TunnelMessagePause,
+		Resume:     TunnelMessageResume,
 	}
+}
+
+func TunnelMessagePause(channelId int) adaptix.TaskData {
+	var packData []byte
+	packerData, _ := msgpack.Marshal(ParamsTunnelPause{ChannelId: channelId})
+	cmd := Command{Code: COMMAND_TUNNEL_PAUSE, Data: packerData}
+	packData, _ = msgpack.Marshal(cmd)
+	return makeProxyTask(packData)
+}
+
+func TunnelMessageResume(channelId int) adaptix.TaskData {
+	var packData []byte
+	packerData, _ := msgpack.Marshal(ParamsTunnelResume{ChannelId: channelId})
+	cmd := Command{Code: COMMAND_TUNNEL_RESUME, Data: packerData}
+	packData, _ = msgpack.Marshal(cmd)
+	return makeProxyTask(packData)
 }
 
 func TunnelMessageConnectTCP(channelId int, tunnelType int, addressType int, address string, port int) adaptix.TaskData {

--- a/AdaptixServer/extenders/gopher_agent/pl_utils.go
+++ b/AdaptixServer/extenders/gopher_agent/pl_utils.go
@@ -217,6 +217,14 @@ type ParamsTunnelStop struct {
 	ChannelId int `msgpack:"channel_id"`
 }
 
+type ParamsTunnelPause struct {
+	ChannelId int `msgpack:"channel_id"`
+}
+
+type ParamsTunnelResume struct {
+	ChannelId int `msgpack:"channel_id"`
+}
+
 type ParamsTerminalStart struct {
 	TermId  int    `msgpack:"term_id"`
 	Program string `msgpack:"program"`
@@ -266,8 +274,10 @@ const (
 	COMMAND_JOB_KILL   = 19
 	COMMAND_REV2SELF   = 20
 
-	COMMAND_TUNNEL_START = 31
-	COMMAND_TUNNEL_STOP  = 32
+	COMMAND_TUNNEL_START  = 31
+	COMMAND_TUNNEL_STOP   = 32
+	COMMAND_TUNNEL_PAUSE  = 33
+	COMMAND_TUNNEL_RESUME = 34
 
 	COMMAND_TERMINAL_START = 35
 	COMMAND_TERMINAL_STOP  = 36

--- a/AdaptixServer/extenders/gopher_agent/src_gopher/utils/utils.go
+++ b/AdaptixServer/extenders/gopher_agent/src_gopher/utils/utils.go
@@ -324,8 +324,10 @@ const (
 	COMMAND_JOB_KILL   = 19
 	COMMAND_REV2SELF   = 20
 
-	COMMAND_TUNNEL_START = 31
-	COMMAND_TUNNEL_STOP  = 32
+	COMMAND_TUNNEL_START  = 31
+	COMMAND_TUNNEL_STOP   = 32
+	COMMAND_TUNNEL_PAUSE  = 33
+	COMMAND_TUNNEL_RESUME = 34
 
 	COMMAND_TERMINAL_START = 35
 	COMMAND_TERMINAL_STOP  = 36
@@ -333,3 +335,11 @@ const (
 	COMMAND_EXEC_BOF     = 50
 	COMMAND_EXEC_BOF_OUT = 51
 )
+
+type ParamsTunnelPause struct {
+	ChannelId int `msgpack:"channel_id"`
+}
+
+type ParamsTunnelResume struct {
+	ChannelId int `msgpack:"channel_id"`
+}


### PR DESCRIPTION
`SOCKS5` connections were hanging - traffic was reaching the server but nothing was being read back.

The issue was that decrypted data was being written to a pipe that nobody was reading from. Fixed by routing data through 
`TsTunnelConnectionData()` instead, which properly feeds the ingress channel.

Also added `pause/resume` flow control to prevent deadlocks during downloads and cleaned up the read loop to handle timeouts gracefully.