### PR TITLE
fix: always serve text/html content-type on error page

### DIFF
--- a/AdaptixServer/extenders/beacon_listener_http/pl_transport.go
+++ b/AdaptixServer/extenders/beacon_listener_http/pl_transport.go
@@ -511,6 +511,7 @@ func (t *TransportHTTP) generateSelfSignedCert(certFile, keyFile string) error {
 
 func (t *TransportHTTP) pageError(ctx *gin.Context) {
 	ctx.Writer.WriteHeader(http.StatusNotFound)
+	ctx.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
 	html := []byte(t.Config.WebPageError)
 	_, _ = ctx.Writer.Write(html)
 }


### PR DESCRIPTION
## Problem
The full error page (`pageError`) was not explicitly setting a
`Content-Type` header, causing the response to either inherit the
client's `TransportHTTP.Config` settings.

## Fix
Explicitly set `Content-Type: text/html; charset=utf-8` before writing
the response body in `pageError`, ensuring the error page is always
served as HTML regardless of the request context.

## Changes
- `pageError`: added explicit `Content-Type: text/html; charset=utf-8`
  header before writing the error page body

## Notes
The header must be set before `Write()` is called — once the body write
begins, headers are flushed and immutable.