### PR TITLE
fix: build error in tc_agents.go and main.go

### DIFF
--- a/AdaptixServer/core/connector/tc_agents.go
+++ b/AdaptixServer/core/connector/tc_agents.go
@@ -97,7 +97,7 @@ func (tc *TsConnector) dispatchAgentCommand(ctx *gin.Context, username string, c
 
 	/// Resolve server-side hooks if client did not provide any
 	if commandData.HookId == "" && commandData.HandlerId == "" {
-		srvHookId, srvHandlerId, preHookHandled, hookErr := tc.teamserver.TsAxScriptResolveHooks(agentName, commandData.AgentId, listenerRegName, agentOs, commandData.CmdLine, args)
+		srvHookId, srvHandlerId, preHookHandled, hookErr := tc.teamserver.TsAxScriptResolveHooks(agentName, commandData.AgentId, listenerRegName, agentOs, commandData.CmdLine, args, username)
 		if hookErr != nil {
 			tc.teamserver.TsAgentConsoleErrorCommand(commandData.AgentId, username, commandData.CmdLine, std.ExtractJsErrorMessage(hookErr), "", "")
 			ctx.JSON(http.StatusOK, gin.H{"message": "", "ok": true})

--- a/AdaptixServer/main.go
+++ b/AdaptixServer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"AdaptixServer/core/connector"
 	"AdaptixServer/core/server"
 	"AdaptixServer/core/utils/logs"
 	"AdaptixServer/core/utils/token"
@@ -10,7 +11,7 @@ import (
 )
 
 func main() {
-	fmt.Printf("\n[===== Adaptix Framework %v =====]\n\n", server.SMALL_VERSION)
+	fmt.Printf("\n[===== Adaptix Framework %v =====]\n\n", connector.SMALL_VERSION)
 
 	var (
 		err         error


### PR DESCRIPTION
Fix build errors caused by a missing argument in TsAxScriptResolveHooks call and an incorrect package reference for SMALL_VERSION.

 `tc_agents.go`: Added missing `username` argument to `TsAxScriptResolveHooks` call
 `main.go`: Import `connector` package and fix `SMALL_VERSION` reference (`server` → `connector`)