### PR TITLE
fix: correct Content-Length header in OTP download handler

### DIFF
--- a/AdaptixServer/core/connector/tc_otp.go
+++ b/AdaptixServer/core/connector/tc_otp.go
@@ -175,7 +175,7 @@ func (tc *TsConnector) tcOTP_DownloadSync(ctx *gin.Context) {
 
 	ctx.Header("Content-Disposition", "attachment; filename="+fileInfo.Name())
 	ctx.Header("Content-Type", "application/octet-stream")
-	ctx.Header("Content-Length", string(rune(fileInfo.Size())))
+	ctx.Header("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
 
 	ctx.File(path)
 }


### PR DESCRIPTION
Found a bug in the OTP download handler in 
AdaptixServer/core/connector/tc_otp.go around line 178.

The Content-Length header was being set incorrectly. The original 
code used string(rune(fileInfo.Size())) which converts the file size 
into a Unicode character instead of a number. So a 65 byte file would 
send Content-Length: A instead of Content-Length: 65. For files over 
1MB it gets even worse and the value becomes meaningless.

Fixed it by using strconv.FormatInt which correctly converts the file 
size to a decimal string.