### PR TITLE
fix(client): unblock sync when teamserver has no data to send

### DIFF
--- a/AdaptixClient/Source/Client/ProcessSyncPacket.cpp
+++ b/AdaptixClient/Source/Client/ProcessSyncPacket.cpp
@@ -543,12 +543,21 @@ void AdaptixWidget::processSyncPacket(QJsonObject jsonObj)
         }
 
         if (count <= 0) {
-            this->sync = false;
+            // No data to sync, but the server still sends SYNC_FINISH.
+            // Keep sync=true so the upcoming SYNC_FINISH triggers
+            // finalizeSyncIfReady(), which closes the splash screen and
+            // emits SyncedSignal. Setting sync=false here would make the
+            // SYNC_FINISH handler (which early-returns when !sync) a no-op,
+            // leaving the client stuck on "data synchronization".
+            this->sync = true;
             this->syncFinishReceived = false;
             this->syncTotalBatches = 0;
             this->syncProcessingBatchIndex = 0;
             this->syncProcessingBatchTotal = 0;
             this->syncProcessingBatchProcessed = 0;
+            this->setSyncUpdateUI(false);
+            if (dialogSyncPacket)
+                dialogSyncPacket->init(count);
             break;
         }
 


### PR DESCRIPTION
## Summary

When the teamserver has no packets to synchronize, it still sends `SYNC_START` (count=0) followed by `SYNC_FINISH`. The client's `count <= 0` branch in `ProcessSyncPacket.cpp` set `sync = false` and returned, which made the subsequent `SYNC_FINISH` handler a no-op (it early-returns when `!sync`). As a result `finalizeSyncIfReady()` never ran, so the splash screen was never closed and `SyncedSignal` was never emitted, leaving the client stuck on "data synchronization".

This change keeps `sync = true` in the `count <= 0` branch so the incoming `SYNC_FINISH` properly finalizes the (empty) sync: it closes the splash screen and emits `SyncedSignal`.

## Changes

- `AdaptixClient/Source/Client/ProcessSyncPacket.cpp`: in the `count <= 0` branch, keep `sync = true`, reset the batch counters, call `setSyncUpdateUI(false)`, and initialize the dialog with `count` so the upcoming `SYNC_FINISH` can finalize.

## Test plan

- [x] Client builds cleanly (incremental CMake build, only pre-existing Qt deprecation warnings).
- [ ] Connect a client to a teamserver that has no stored packets and confirm the splash closes and the UI becomes usable (no longer stuck on "data synchronization").
- [ ] Confirm the normal (count > 0) sync path is unaffected.