### PR TITLE
Fix spurious nproc error on non-Linux hosts in beacon build

### DIFF
--- a/AdaptixServer/extenders/beacon_agent/src_beacon/Makefile
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/Makefile
@@ -47,7 +47,7 @@ MINIZ_TRIM_FLAGS := -DMINIZ_NO_STDIO -DMINIZ_NO_ARCHIVE_APIS -DMINIZ_NO_ARCHIVE_
 
 .PHONY: all clean pre x64 x86
 
-NPROC := $(shell nproc)
+NPROC := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 ifeq ($(MAKELEVEL), 0)
     MAKEFLAGS += -j$(NPROC) --no-print-directory
 endif


### PR DESCRIPTION
## Problem

Building the server extenders on macOS prints:

```
make[2]: nproc: No such file or directory
```

`AdaptixServer/extenders/beacon_agent/src_beacon/Makefile` calls `nproc` unconditionally to set the parallel job count. `nproc` is a GNU coreutils tool and isn't present on macOS (or other non-GNU systems), so the command fails. The build still completes, but the error is misleading noise.

Note: the top-level `Makefile` already guards this with a `uname -s` check — only the beacon sub-Makefile was missing the equivalent.

## Fix

Resolve the core count portably:

```make
NPROC := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
```

- Linux: `nproc`
- macOS/BSD: `sysctl -n hw.ncpu`
- fallback: `4`

No more spurious error, and `-j$(NPROC)` now gets a real value on all platforms.

## Testing

`make server-ext` on macOS — build completes with no `nproc` error.