### PR TITLE
fix: add SessionKey to applyAgentUpdate fieldAccessor

### DIFF
--- a/AdaptixServer/core/server/ts_agent.go
+++ b/AdaptixServer/core/server/ts_agent.go
@@ -448,6 +448,7 @@ func (ts *Teamserver) applyAgentUpdate(agent *adaptix.Agent, updateData interfac
 		Color        *string `json:"color,omitempty"`
 		Listener     *string `json:"listener,omitempty"`
 		CustomData   *string `json:"custom_data,omitempty"`
+		SessionKey   *[]byte `json:"a_session_key,omitempty"`
 		Sleep        *uint   `json:"sleep,omitempty"`
 		Jitter       *uint   `json:"jitter,omitempty"`
 		WorkingTime  *int    `json:"working_time,omitempty"`
@@ -594,6 +595,10 @@ func (ts *Teamserver) applyAgentUpdate(agent *adaptix.Agent, updateData interfac
 		}
 		if fields.CustomData != nil {
 			d.CustomData = []byte(*fields.CustomData)
+			updated = true
+		}
+		if fields.SessionKey != nil {
+			d.SessionKey = *fields.SessionKey
 			updated = true
 		}
 		if fields.Sleep != nil {


### PR DESCRIPTION
Closes #347

`fieldAccessor` in `applyAgentUpdate` was missing `SessionKey`, causing
`TsAgentUpdateDataPartial` to silently drop `a_session_key` updates.