### PR TITLE
feat: expose original file path for file args in AxScript

### DIFF
--- a/AdaptixServer/core/axscript/manager.go
+++ b/AdaptixServer/core/axscript/manager.go
@@ -497,6 +497,7 @@ func (sm *ScriptManager) resolveFileArgs(engine *ScriptEngine, parsed *ParsedCom
 			return fmt.Errorf("cannot read file for argument '%s': %w", fa.ArgName, err)
 		}
 		parsed.Args[fa.ArgName] = base64.StdEncoding.EncodeToString(data)
+		parsed.Args[fa.ArgName+"_path"] = fa.OriginalPath
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #349

For each file argument, store the original path in args["<name>_path"]
alongside the base64 content in args["<name>"].