### PR TITLE
Fix build: ScriptsFilterProxy calls nonexistent endFilterChange()

### DIFF
--- a/AdaptixClient/Headers/UI/Widgets/ScriptsWidget.h
+++ b/AdaptixClient/Headers/UI/Widgets/ScriptsWidget.h
@@ -59,7 +59,7 @@ Q_OBJECT
 
 public:
     explicit ScriptsFilterProxy(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
-    void setSearchText(const QString& text) { m_searchText = text; beginFilterChange(); endFilterChange(); }
+    void setSearchText(const QString& text) { m_searchText = text; invalidateFilter(); }
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;


### PR DESCRIPTION
Fixes #352

`endFilterChange()` isn't part of `QSortFilterProxyModel`. Swap to `invalidateFilter()`,
same as every other filter proxy in this codebase.
