### PR TITLE
feat: Adding Folder selector feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ AdaptixClient/AdaptixClient_autogen/
 AdaptixClient/CMakeCache.txt
 AdaptixClient/*.log
 AdaptixClient/cmake_*
+AdaptixClient/cmake
 AdaptixClient/Makefile
 AdaptixServer/build_error.log
 

--- a/AdaptixClient/CMakeLists.txt
+++ b/AdaptixClient/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 find_package(Qt6
         REQUIRED COMPONENTS
         Core
+        CorePrivate
         Gui
         Widgets
         Network
@@ -266,9 +267,16 @@ target_compile_definitions(
 #        QT_NO_SIGNALS_SLOTS_KEYWORDS
 )
 
+if(MSVC)
+        target_compile_options(AdaptixClient PRIVATE /wd4996)
+else()
+        target_compile_options(AdaptixClient PRIVATE -Wno-deprecated-declarations)
+endif()
+
 target_link_libraries( AdaptixClient
         PRIVATE
         Qt6::Core
+        Qt6::CorePrivate
         Qt6::Gui
         Qt6::Widgets
         Qt6::Network

--- a/AdaptixClient/Headers/Client/AxScript/AxElementWrappers.h
+++ b/AdaptixClient/Headers/Client/AxScript/AxElementWrappers.h
@@ -911,6 +911,31 @@ private Q_SLOTS:
     void onSelectFile();
 };
 
+/// SELECTOR FOLDER
+
+class AxSelectorFolder : public QObject, public AbstractAxElement, public AbstractAxVisualElement {
+Q_OBJECT
+    QLineEdit* lineEdit;
+    QString    content;
+
+public:
+    explicit AxSelectorFolder(QLineEdit* edit, QObject* parent = nullptr);
+
+    QVariant jsonMarshal() const override;
+    void jsonUnmarshal(const QVariant& value) override;
+
+    QLineEdit* widget() const override;
+    Q_INVOKABLE void setEnabled(const bool enable) const override { widget()->setEnabled(enable); }
+    Q_INVOKABLE void setVisible(const bool enable) const override { widget()->setVisible(enable); }
+    Q_INVOKABLE bool getEnabled() const override { return widget()->isEnabled(); }
+    Q_INVOKABLE bool getVisible() const override { return widget()->isVisible(); }
+
+    Q_INVOKABLE void setPlaceholder(const QString& text) const;
+
+private Q_SLOTS:
+    void onSelectFolder();
+};
+
 
 
 /// SELECTOR CREDENTIALS

--- a/AdaptixClient/Headers/Client/AxScript/BridgeForm.h
+++ b/AdaptixClient/Headers/Client/AxScript/BridgeForm.h
@@ -58,6 +58,7 @@ public Q_SLOTS:
     QObject* create_dialog(const QString &title) const;
 
     QObject* create_selector_file();
+    QObject* create_selector_folder();
     QObject* create_selector_credentials(const QJSValue &headers) const;
     QObject* create_selector_agents(const QJSValue &headers) const;
     QObject* create_selector_listeners(const QJSValue &headers) const;

--- a/AdaptixClient/Source/Client/AxScript/AxElementWrappers.cpp
+++ b/AdaptixClient/Source/Client/AxScript/AxElementWrappers.cpp
@@ -15,6 +15,10 @@
 #include <oclero/qlementine/widgets/Menu.hpp>
 #include <oclero/qlementine/widgets/Switch.hpp>
 #include <oclero/qlementine/widgets/SegmentedControl.hpp>
+#include <QBuffer>
+#include <QDirIterator>
+#include <QFileInfo>
+#include <QtCore/private/qzipwriter_p.h>
 
 /// MENU
 
@@ -1175,6 +1179,103 @@ void AxSelectorFile::onSelectFile()
             file.close();
 
             content = QString::fromUtf8(fileData.toBase64());
+        });
+}
+
+/// FOLDER SELECTOR
+
+namespace {
+bool zipFolderToData(const QString& folderPath, QByteArray& outZipData)
+{
+    const QFileInfo folderInfo(folderPath);
+    if (!folderInfo.exists() || !folderInfo.isDir())
+        return false;
+
+    QBuffer zipBuffer;
+    if (!zipBuffer.open(QIODevice::WriteOnly))
+        return false;
+
+    QZipWriter zipWriter(&zipBuffer);
+    zipWriter.setCompressionPolicy(QZipWriter::AutoCompress);
+
+    QDir rootDir(folderInfo.absoluteFilePath());
+    const QString rootName = rootDir.dirName();
+    zipWriter.addDirectory(rootName + "/");
+
+    QDirIterator it(
+        folderInfo.absoluteFilePath(),
+        QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System,
+        QDirIterator::Subdirectories
+    );
+
+    while (it.hasNext()) {
+        it.next();
+        const QFileInfo entryInfo = it.fileInfo();
+        const QString relPath = rootDir.relativeFilePath(entryInfo.absoluteFilePath());
+        QString zipPath = rootName + "/" + relPath;
+        zipPath.replace('\\', '/');
+
+        if (entryInfo.isDir()) {
+            if (!zipPath.endsWith('/'))
+                zipPath += '/';
+            zipWriter.addDirectory(zipPath);
+            continue;
+        }
+
+        if (entryInfo.isFile()) {
+            QFile file(entryInfo.absoluteFilePath());
+            if (!file.open(QIODevice::ReadOnly))
+                return false;
+
+            zipWriter.addFile(zipPath, file.readAll());
+
+            if (zipWriter.status() != QZipWriter::NoError)
+                return false;
+        }
+    }
+
+    zipWriter.close();
+    if (zipWriter.status() != QZipWriter::NoError)
+        return false;
+
+    outZipData = zipBuffer.data();
+    return !outZipData.isEmpty();
+}
+}
+
+AxSelectorFolder::AxSelectorFolder(QLineEdit* edit, QObject* parent) : QObject(parent), lineEdit(edit)
+{
+    lineEdit->setReadOnly(true);
+
+    auto action = lineEdit->addAction(QIcon(":/icons/folder"), QLineEdit::TrailingPosition);
+    connect(action, &QAction::triggered, this, &AxSelectorFolder::onSelectFolder);
+}
+
+QLineEdit* AxSelectorFolder::widget() const { return lineEdit; }
+
+QVariant AxSelectorFolder::jsonMarshal() const { return content; }
+
+void AxSelectorFolder::jsonUnmarshal(const QVariant& value)
+{
+    content = value.toString();
+    lineEdit->setText("Selected...");
+}
+
+void AxSelectorFolder::setPlaceholder(const QString& text) const { lineEdit->setPlaceholderText(text); }
+
+void AxSelectorFolder::onSelectFolder()
+{
+    NonBlockingDialogs::getExistingDirectory(lineEdit, "Select a folder", "",
+        [this](const QString& selectedFolder) {
+            if (selectedFolder.isEmpty())
+                return;
+
+            QByteArray zipData;
+            if (!zipFolderToData(selectedFolder, zipData))
+                return;
+
+            lineEdit->setText(selectedFolder);
+            content = QString::fromUtf8(zipData.toBase64());
         });
 }
 

--- a/AdaptixClient/Source/Client/AxScript/BridgeForm.cpp
+++ b/AdaptixClient/Source/Client/AxScript/BridgeForm.cpp
@@ -272,6 +272,14 @@ QObject* BridgeForm::create_selector_file()
     return wrapper;
 }
 
+QObject* BridgeForm::create_selector_folder()
+{
+    auto* lineEdit = new QLineEdit(getParentWidget());
+    auto* wrapper = new AxSelectorFolder(lineEdit, this);
+    scriptEngine->registerObject(wrapper);
+    return wrapper;
+}
+
 QObject* BridgeForm::create_tabs()
 {
     auto* tabWidget = new QTabWidget(getParentWidget());

--- a/AdaptixServer/core/axscript/bridge_stubs.go
+++ b/AdaptixServer/core/axscript/bridge_stubs.go
@@ -88,6 +88,7 @@ func registerFormStubs(engine *ScriptEngine) {
 	// Selectors
 	formObj.Set("create_file_chooser", func(call goja.FunctionCall) goja.Value { return newStubWidget(rt) })
 	formObj.Set("create_selector_file", func(call goja.FunctionCall) goja.Value { return newStubWidget(rt) })
+	formObj.Set("create_selector_folder", func(call goja.FunctionCall) goja.Value { return newStubWidget(rt) })
 	formObj.Set("create_selector_credentials", func(call goja.FunctionCall) goja.Value { return newStubWidget(rt) })
 	formObj.Set("create_selector_agents", func(call goja.FunctionCall) goja.Value { return newStubWidget(rt) })
 	formObj.Set("create_selector_listeners", func(call goja.FunctionCall) goja.Value { return newStubWidget(rt) })

--- a/AdaptixServer/go.work.sum
+++ b/AdaptixServer/go.work.sum
@@ -20,11 +20,13 @@ github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/gabriel-vasile/mimetype v1.4.11/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/validator/v10 v10.28.0/go.mod h1:GoI6I1SjPBh9p7ykNE/yj3fFYbyDOpwMn5KXd+m2hUU=
 github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2 h1:rcanfLhLDA8nozr/K289V1zcntHr3V+SHlXwzz1ZI2g=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
@@ -32,6 +34,7 @@ github.com/jordanlewis/gcassert v0.0.0-20250430164644-389ef753e22e h1:a+PGEeXb+e
 github.com/jordanlewis/gcassert v0.0.0-20250430164644-389ef753e22e/go.mod h1:ZybsQk6DWyN5t7An1MuPm1gtSZ1xDaTXS9ZjIOxvQrk=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/knz/go-libedit v1.10.1 h1:0pHpWtx9vcvC0xGZqEQlQdfSQs7WRlAjuPvk3fOZDCo=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -50,6 +53,7 @@ github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5E
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/quic-go/quic-go v0.57.0/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -145,6 +149,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 nullprogram.com/x/optparse v1.0.0 h1:xGFgVi5ZaWOnYdac2foDT3vg0ZZC9ErXFV57mr4OHrI=


### PR DESCRIPTION
## Summary

Adds Folder Selector to the Adaptix Client

## Features

Create a folder selector `create_selector_folder` with the same behaviour as create_selector_file, to get the base64+zip content for a local folder. This can be used to transfer some folder recursivly between the AdaptixClient & AdaptixServer.

## Design

- Use Qt6 CorePrivate with `qzipwriter_p` to zip a folder
- Object `create_selector_folder` is available for `.axs` scripts
- Same behaviour and structure as `AxSelectorFile`

## Test Plan

- Build AdaptixServer