### PR TITLE
fix beacon_agent circular references(and remove unnecessary forward declaration)

### DIFF
--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/Agent.cpp
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/Agent.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 #include "Packer.h"
 #include "Crypt.h"
+#include "Commander.h"
 
 void* Agent::operator new(size_t sz) 
 {

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/Agent.h
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/Agent.h
@@ -7,7 +7,6 @@
 #include "MemorySaver.h"
 #include "Proxyfire.h"
 #include "Pivotter.h"
-#include "Commander.h"
 #include "Boffer.h"
 
 class Commander;

--- a/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/Commander.h
+++ b/AdaptixServer/extenders/beacon_agent/src_beacon/beacon/Commander.h
@@ -35,7 +35,7 @@
 #define COMMAND_SAVEMEMORY 0x2321
 #define COMMAND_ERROR      0x1111ffff
 
-class Agent;
+
 
 class Commander
 {


### PR DESCRIPTION
- ```Agent.h``` includes ```Commander.h```, then ```Commander.h``` includes ```Agent.h```
- ```Commander.h``` already includes "Agent.h" that makes forward declaration ```class Agent;``` in ```Commander.h``` unnecessary